### PR TITLE
Add `host` attribute to various Paper API routes

### DIFF
--- a/paper.stone
+++ b/paper.stone
@@ -593,6 +593,7 @@ route docs/permanently_delete (RefPaperDoc, Void, DocLookupError)
 route docs/download (PaperDocExport, PaperDocExportResult, DocLookupError)
     "Exports and downloads Paper doc either as HTML or markdown."
     attrs
+        host="content"
         style="download"
         owner="paper-eng"
 
@@ -658,11 +659,13 @@ route docs/list/continue (ListPaperDocsContinueArgs, ListPaperDocsResponse, List
 route docs/create (PaperDocCreateArgs, PaperDocCreateUpdateResult, PaperDocCreateError)
     "Creates a new Paper doc with the provided content."
     attrs
+        host="content"
         style="upload"
         owner="paper-eng"
 
 route docs/update (PaperDocUpdateArgs, PaperDocCreateUpdateResult, PaperDocUpdateError)
     "Updates an existing Paper doc with the provided content."
     attrs
+        host="content"
         style="upload"
         owner="paper-eng"


### PR DESCRIPTION
`/docs/create`, and `/docs/update` are `Content-upload` endpoints.
`/docs/download` is a `Content-download` endpoint.
Their `style` are defined, but they were missing the `host` definition.

---

This will allow us to generate working client code in https://github.com/dropbox/dropbox-sdk-go-unofficial/.

See official documentation https://www.dropbox.com/developers/documentation/http/documentation#paper-docs-create

```
ENDPOINT FORMAT
Content-upload
```