### PR TITLE
Update specs

### DIFF
--- a/files.stone
+++ b/files.stone
@@ -2885,7 +2885,6 @@ route lock_file_batch (LockFileBatchArg, LockFileBatchResult, LockFileError)
     "
 
     attrs
-        is_preview = true
         scope = "files.content.write"
 
 #
@@ -2901,7 +2900,6 @@ route unlock_file_batch (UnlockFileBatchArg, LockFileBatchResult, LockFileError)
     "
 
     attrs
-        is_preview = true
         select_admin_mode = "whole_team"
         scope = "files.content.write"
 
@@ -2915,7 +2913,6 @@ route get_file_lock_batch (LockFileBatchArg, LockFileBatchResult, LockFileError)
     "
 
     attrs
-        is_preview = true
         scope = "files.content.read"
 
 #

--- a/stone_cfg.stone
+++ b/stone_cfg.stone
@@ -20,3 +20,5 @@ struct Route
         Valid values: team_admin, whole_team."
     scope String?
         "Name of the scope required to call this route."
+    is_cloud_doc_auth Boolean = false
+        "Whether the endpoint is a Dropbox cloud docs endpoint which takes cloud docs auth token."

--- a/team_legal_holds.stone
+++ b/team_legal_holds.stone
@@ -3,14 +3,11 @@ namespace team
 import common
 import team_common
 import files
-import async
 
 alias LegalHoldId = String(pattern="^pid_dbhid:.+")
 alias LegalHoldPolicyName = String(max_length=140)
 alias LegalHoldPolicyDescription = String(max_length=501)
 alias Path = String(pattern="(/(.|[\\r\\n])*)?")
-alias UserId = UInt64
-alias NSpath = String(pattern="(ns:[0-9]+(/.*)?)")
 
 union LegalHoldStatus
     active
@@ -274,91 +271,9 @@ route legal_holds/list_held_revisions_continue(LegalHoldsListHeldRevisionsContin
         scope = "team_data.member"
 
 #
-# route legal_holds/export_policy
-#
-
-struct LegalHoldsPolicyExportArg
-    id LegalHoldId
-        "The legal hold Id."
-    path NSpath
-        "The selected destination path in the team's Dropbox for the export.
-        The path must be a namespace path (see example) of a namespace that's accessible to the
-        application. To get the list of accessible namespaces use the
-        route :route:`namespaces/list`."
-
-
-    example default
-        id = "pid_dbhid:abcd1234"
-        path = "ns:123/Legal holds exports"
-
-    example root
-        id = "pid_dbhid:abcd1234"
-        path = "ns:123"
-
-struct LegalHoldsExportPolicyResult
-    async_job_id async.AsyncJobId
-        "Pass the given ID into :route:`legal_holds/export_policy_job_status/check` to
-        obtain the status of the export policy job status."
-    export_folder_metadata files.FolderMetadata
-        "Metadata for the newly created folder that will eventually, once the export policy job completes,
-        include the hold's export."
-
-    example default
-        async_job_id = "34g93hh34h04y384084"
-        export_folder_metadata = default
-
-
-union LegalHoldsExportPolicyError
-    invalid_path
-        "The path provided is invalid."
-    legal_hold_performing_another_operation
-        "Legal hold is currently performing another operation."
-    unknown_legal_hold_error
-        "There has been an unknown legal hold error."
-    transient_error
-        "Temporary infrastructure failure, please retry."
-    insufficient_quota
-        "The current team does not have enough space to export the legal hold policy."
-    legal_hold_export_still_empty
-        "The legal hold is not holding any revisions yet"
-
-
-
-route legal_holds/export_policy(LegalHoldsPolicyExportArg, LegalHoldsExportPolicyResult, LegalHoldsExportPolicyError) deprecated
-    "Export everything for a single hold to a Dropbox file path.
-
-    Permission : Team member file access."
-
-    attrs
-        auth = "team"
-        scope = "team_data.member"
-
-#
-# route legal_holds/export_policy_job_status/check
-#
-
-union ExportPolicyJobStatus extends async.PollResultBase
-    complete
-        "The asynchronous job has finished. Returning the metadata of the newly created folder that includes the exported hold."
-    failed
-        "The asynchronous job returned an error."
-
-struct ExportPolicyJobStatusResult
-    status ExportPolicyJobStatus
-
-
-route legal_holds/export_policy_job_status/check(async.PollArg, ExportPolicyJobStatusResult, async.PollError) deprecated
-    "Returns the status of an asynchronous job for :route:`legal_holds/export_policy_job_status/check`.
-
-    Permission : Team member file access."
-
-    attrs
-        auth = "team"
-        scope = "team_data.member"
-
-#
 # route legal_holds/update_policy
 #
+
 struct LegalHoldsPolicyUpdateArg
     id LegalHoldId
         "The legal hold Id."

--- a/team_log.stone
+++ b/team_log.stone
@@ -66,7 +66,10 @@ union GetTeamEventsError
         account_id_not_found = null
 
 route get_events(GetTeamEventsArg, GetTeamEventsResult, GetTeamEventsError)
-    "Retrieves team events.
+    "Retrieves team events. If the result's :field:`GetTeamEventsResult.has_more` field is
+    :val:`true`, call :route:`get_events/continue` with the returned cursor to retrieve
+    more entries. If end_time is not specified in your request, you may use the returned cursor to
+    poll :route:`get_events/continue` for new events.
 
     Many attributes note 'may be missing due to historical data gap'.
 

--- a/team_log_generated.stone
+++ b/team_log_generated.stone
@@ -76,6 +76,10 @@ union AccountCapturePolicy
     invited_users
     all_users
 
+union AccountState
+    locked
+    unlocked
+
 union ActionDetails
     "Additional information indicating the action taken that caused status change."
 
@@ -476,11 +480,18 @@ union LoginMethod
     web_session
     qr_code
     apple_oauth
+    first_party_token_exchange
 
 union MemberRequestsPolicy
     auto_accept
     disabled
     require_approval
+
+union MemberSendInvitePolicy
+    "Policy for controlling whether team members can send team invites"
+    disabled
+    specific_members
+    everyone
 
 union MemberStatus
     not_joined
@@ -1307,16 +1318,20 @@ struct FileOrFolderLogInfo
         "Display name. Might be missing due to historical data gap."
     file_id String?
         "Unique ID. Might be missing due to historical data gap."
+    file_size UInt64?
+        "File or folder size in bytes."
 
     example default
         path = default
         display_name = "reports.xls"
         file_id = "id:jQKLsZFQImAAAAAAEZAAQt"
+        file_size = 3
 
     example default2
         path = default2
         display_name = "reports.xls"
         file_id = "id:jQKLsZFQImAAAAAAEZAAQt"
+        file_size = 4
 
 struct FileLogInfo extends FileOrFolderLogInfo
     "File's logged information."
@@ -1325,24 +1340,33 @@ struct FileLogInfo extends FileOrFolderLogInfo
         path = default
         display_name = "reports.xls"
         file_id = "id:jQKLsZFQImAAAAAAEZAAQt"
+        file_size = 3
 
     example default2
         path = default2
         display_name = "reports.xls"
         file_id = "id:jQKLsZFQImAAAAAAEZAAQt"
+        file_size = 4
 
 struct FolderLogInfo extends FileOrFolderLogInfo
     "Folder's logged information."
+
+    file_count UInt64?
+        "Number of files within the folder."
 
     example default
         path = default
         display_name = "reports.xls"
         file_id = "id:jQKLsZFQImAAAAAAEZAAQt"
+        file_size = 3
+        file_count = 3
 
     example default2
         path = default2
         display_name = "reports.xls"
         file_id = "id:jQKLsZFQImAAAAAAEZAAQt"
+        file_size = 4
+        file_count = 4
 
 struct GroupLogInfo 
     "Group's logged information."
@@ -2477,6 +2501,18 @@ struct LegalHoldsReportAHoldDetails
     example default
         legal_hold_id = "abc"
         name = "abc"
+
+struct AccountLockOrUnlockedDetails
+    "Unlocked/locked account after failed sign in attempts."
+
+    previous_value AccountState
+        "The previous account status."
+    new_value AccountState
+        "The new account status."
+
+    example default
+        previous_value = locked
+        new_value = locked
 
 struct EmmErrorDetails
     "Failed to sign in via EMM."
@@ -4849,6 +4885,18 @@ struct MemberRequestsChangePolicyDetails
         new_value = require_approval
         previous_value = require_approval
 
+struct MemberSendInvitePolicyChangedDetails
+    "Changed member send invite policy for team."
+
+    new_value MemberSendInvitePolicy
+        "New team member send invite policy."
+    previous_value MemberSendInvitePolicy
+        "Previous team member send invite policy."
+
+    example default
+        new_value = disabled
+        previous_value = disabled
+
 struct MemberSpaceLimitsAddExceptionDetails
     "Added members to member space limit exception list."
 
@@ -5758,6 +5806,7 @@ union EventDetails
     legal_holds_release_a_hold_details LegalHoldsReleaseAHoldDetails
     legal_holds_remove_members_details LegalHoldsRemoveMembersDetails
     legal_holds_report_a_hold_details LegalHoldsReportAHoldDetails
+    account_lock_or_unlocked_details AccountLockOrUnlockedDetails
     emm_error_details EmmErrorDetails
     guest_admin_signed_in_via_trusted_teams_details GuestAdminSignedInViaTrustedTeamsDetails
     guest_admin_signed_out_via_trusted_teams_details GuestAdminSignedOutViaTrustedTeamsDetails
@@ -6002,6 +6051,7 @@ union EventDetails
     group_user_management_change_policy_details GroupUserManagementChangePolicyDetails
     integration_policy_changed_details IntegrationPolicyChangedDetails
     member_requests_change_policy_details MemberRequestsChangePolicyDetails
+    member_send_invite_policy_changed_details MemberSendInvitePolicyChangedDetails
     member_space_limits_add_exception_details MemberSpaceLimitsAddExceptionDetails
     member_space_limits_change_caps_type_policy_details MemberSpaceLimitsChangeCapsTypePolicyDetails
     member_space_limits_change_policy_details MemberSpaceLimitsChangePolicyDetails
@@ -6627,6 +6677,12 @@ struct LegalHoldsReportAHoldType
 
     example default
         description = "(legal_holds) Created a summary report for a hold"
+
+struct AccountLockOrUnlockedType
+    description String
+
+    example default
+        description = "(logins) Unlocked/locked account after failed sign in attempts"
 
 struct EmmErrorType
     description String
@@ -8092,6 +8148,12 @@ struct MemberRequestsChangePolicyType
     example default
         description = "(team_policies) Changed whether users can find team when not invited"
 
+struct MemberSendInvitePolicyChangedType
+    description String
+
+    example default
+        description = "(team_policies) Changed member send invite policy for team"
+
 struct MemberSpaceLimitsAddExceptionType
     description String
 
@@ -8760,6 +8822,8 @@ union EventType
         "(legal_holds) Removed members from a hold"
     legal_holds_report_a_hold LegalHoldsReportAHoldType
         "(legal_holds) Created a summary report for a hold"
+    account_lock_or_unlocked AccountLockOrUnlockedType
+        "(logins) Unlocked/locked account after failed sign in attempts"
     emm_error EmmErrorType
         "(logins) Failed to sign in via EMM (deprecated, replaced by 'Failed to sign in')"
     guest_admin_signed_in_via_trusted_teams GuestAdminSignedInViaTrustedTeamsType
@@ -9248,6 +9312,8 @@ union EventType
         "(team_policies) Changed integration policy for team"
     member_requests_change_policy MemberRequestsChangePolicyType
         "(team_policies) Changed whether users can find team when not invited"
+    member_send_invite_policy_changed MemberSendInvitePolicyChangedType
+        "(team_policies) Changed member send invite policy for team"
     member_space_limits_add_exception MemberSpaceLimitsAddExceptionType
         "(team_policies) Added members to member space limit exception list"
     member_space_limits_change_caps_type_policy MemberSpaceLimitsChangeCapsTypePolicyType


### PR DESCRIPTION
Change Notes:
Stone configuration
- added a new route property `is_cloud_doc_auth` indicating whether the endpoint is a Dropbox cloud docs endpoint which takes cloud docs auth token.

Files namespace
- `lock_file_batch`, `unlock_file_batch` and `get_file_lock_batch` are no longer preview routes

Team namespace
- Deleted deprecated routes `legal_holds/export_policy` and `legal_holds/export_policy_job_status/check`

Team_log namespace:
- Added `AccountState` union
- Added `AccountLockOrUnlockedType` struct
- Added `AccountLockOrUnlockedDetails` struct
- Added `MemberSendInvitePolicy` union
- Added `MemberSendInvitePolicyChangedType` struct
- Added `MemberSendInvitePolicyChangedDetails` struct
- Added a new tag `first_party_token_exchange` to `LoginMethod` union 
- Added new tags `account_lock_or_unlocked_details` and `member_send_invite_policy_changed_details` to `EventDetails` union
-  Added new tags `account_lock_or_unlocked` and `member_send_invite_policy_changed` to `EventType` union
- Added a new field `file_size` to `FileOrFolderLogInfo` and `FileLogInfo` struct 
-  Added a new field `file_count` to `FolderLogInfo` struct 