### PR TITLE
Spec Update 10/15/2020

### DIFF
--- a/files.stone
+++ b/files.stone
@@ -1222,11 +1222,13 @@ struct SearchV2Arg
     match_field_options SearchMatchFieldOptions?
         "Options for search results match fields."
 
-    include_highlights Boolean = false
+    include_highlights Boolean?
         "Deprecated and moved this option to SearchMatchFieldOptions."
 
     example default
         query = "cat"
+        options = default
+        match_field_options = default
 
 struct SearchOptions
 
@@ -1235,6 +1237,9 @@ struct SearchOptions
 
     max_results UInt64(min_value=1, max_value=1000) = 100
         "The maximum number of search results to return."
+
+    order_by SearchOrderBy?
+        "Specified property of the order of search results. By default, results are sorted by relevance."
 
     file_status FileStatus = active
         "Restricts search to the given file status."
@@ -1249,13 +1254,22 @@ struct SearchOptions
         "Restricts search to only the file categories specified. Only supported for active file search."
 
     example default
-        path = ""
+        path = "/Folder"
         max_results = 20
 
 struct SearchMatchFieldOptions
 
     include_highlights Boolean = false
         "Whether to include highlight span from file title."
+    example default
+        include_highlights = false
+
+union SearchOrderBy
+    relevance
+    last_modified_time
+
+    example default
+        relevance = null
 
 # both -- maybe supported in the future
 union FileStatus
@@ -1342,6 +1356,9 @@ struct SearchMatchV2
     metadata MetadataV2
         "The metadata for the matched file or folder."
 
+    match_type SearchMatchTypeV2?
+        "The type of the match."
+
     highlight_spans List(HighlightSpan)?
         "The list of HighlightSpan determines which parts of the file title should be highlighted."
 
@@ -1349,6 +1366,17 @@ struct SearchMatchV2
         metadata = default
         highlight_spans = null
 
+union SearchMatchTypeV2
+    "Indicates what type of match was found for a given item."
+
+    filename
+        "This item was matched on its file or folder name."
+    file_content
+        "This item was matched based on its file contents."
+    filename_and_content
+        "This item was matched based on both its contents and its file name."
+    image_content
+        "This item was matched on image content."
 
 #
 # Errors shared by various operations

--- a/team_log_generated.stone
+++ b/team_log_generated.stone
@@ -691,6 +691,11 @@ union SpaceLimitsStatus
     over_quota
     within_quota
 
+union TeamBrandingPolicy
+    "Policy for controlling team access to setting up branding feature"
+    disabled
+    enabled
+
 union TeamExtensionsPolicy
     "Policy for controlling whether App Integrations are enabled for the team."
     disabled
@@ -5540,6 +5545,18 @@ struct SsoChangePolicyDetails
         new_value = disabled
         previous_value = disabled
 
+struct TeamBrandingPolicyChangedDetails
+    "Changed team branding policy for team."
+
+    new_value TeamBrandingPolicy
+        "New team branding policy."
+    previous_value TeamBrandingPolicy
+        "Previous team branding policy."
+
+    example default
+        new_value = disabled
+        previous_value = disabled
+
 struct TeamExtensionsPolicyChangedDetails
     "Changed App Integrations setting for team."
 
@@ -6426,6 +6443,7 @@ union EventDetails
     smart_sync_not_opt_out_details SmartSyncNotOptOutDetails
     smart_sync_opt_out_details SmartSyncOptOutDetails
     sso_change_policy_details SsoChangePolicyDetails
+    team_branding_policy_changed_details TeamBrandingPolicyChangedDetails
     team_extensions_policy_changed_details TeamExtensionsPolicyChangedDetails
     team_selective_sync_policy_changed_details TeamSelectiveSyncPolicyChangedDetails
     team_sharing_whitelist_subjects_changed_details TeamSharingWhitelistSubjectsChangedDetails
@@ -8810,6 +8828,12 @@ struct SsoChangePolicyType
     example default
         description = "(team_policies) Changed single sign-on setting for team"
 
+struct TeamBrandingPolicyChangedType
+    description String
+
+    example default
+        description = "(team_policies) Changed team branding policy for team"
+
 struct TeamExtensionsPolicyChangedType
     description String
 
@@ -9894,6 +9918,8 @@ union EventType
         "(team_policies) Opted team out of Smart Sync"
     sso_change_policy SsoChangePolicyType
         "(team_policies) Changed single sign-on setting for team"
+    team_branding_policy_changed TeamBrandingPolicyChangedType
+        "(team_policies) Changed team branding policy for team"
     team_extensions_policy_changed TeamExtensionsPolicyChangedType
         "(team_policies) Changed App Integrations setting for team"
     team_selective_sync_policy_changed TeamSelectiveSyncPolicyChangedType
@@ -10778,6 +10804,8 @@ union EventTypeArg
         "(team_policies) Opted team out of Smart Sync"
     sso_change_policy
         "(team_policies) Changed single sign-on setting for team"
+    team_branding_policy_changed
+        "(team_policies) Changed team branding policy for team"
     team_extensions_policy_changed
         "(team_policies) Changed App Integrations setting for team"
     team_selective_sync_policy_changed

--- a/team_reports.stone
+++ b/team_reports.stone
@@ -70,7 +70,7 @@ struct GetStorageReport extends BaseDfbReport
         number of users in that bucket. There is one such summary per day.
         If there is no data for a day, the storage summary will be empty."
 
-route reports/get_storage(DateRange, GetStorageReport, DateRangeError)
+route reports/get_storage(DateRange, GetStorageReport, DateRangeError) deprecated
     "Retrieves reporting data about a team's storage usage."
     attrs
         auth = "team"
@@ -115,7 +115,7 @@ struct GetActivityReport extends BaseDfbReport
     shared_links_viewed_total NumberPerDay
         "Array of the total number of views to shared links created by the team."
 
-route reports/get_activity(DateRange, GetActivityReport, DateRangeError)
+route reports/get_activity(DateRange, GetActivityReport, DateRangeError) deprecated
     "Retrieves reporting data about a team's user activity."
     attrs
         auth = "team"
@@ -143,7 +143,7 @@ struct GetMembershipReport extends BaseDfbReport
 
 
 
-route reports/get_membership(DateRange, GetMembershipReport, DateRangeError)
+route reports/get_membership(DateRange, GetMembershipReport, DateRangeError) deprecated
     "Retrieves reporting data about a team's membership."
     attrs
         auth = "team"
@@ -190,7 +190,7 @@ struct GetDevicesReport extends BaseDfbReport
         "Report of the number of devices active in the last 28 days."
 
 
-route reports/get_devices(DateRange, GetDevicesReport, DateRangeError)
+route reports/get_devices(DateRange, GetDevicesReport, DateRangeError) deprecated
     "Retrieves reporting data about a team's linked devices."
     attrs
         auth = "team"


### PR DESCRIPTION
Change Notes:

File Namespace:
- Add SearchOrderBy unioin
- Add SearchMatchTypeV2 union
- Update SearchOptions to include order_by
- Update SearchMatchV2 to include match_type

Team Audit Log Namespace:
- Add TeamBrandingPolicy union
- Add TeamBrandingPolicyChangedDetails struct
- Add TeamBrandingPolicyChangedType struct
- Update EventDetails to include team_branding_policy_changed_details
- Update EventType to include team_branding_policy_changed
- Update EventTypeArg to include team_branding_policy_changed

Team Reports Namespace:
- Deprecate reports/get_storage
- Deprecate reports/get_activity
- Deprecate reports/get_membership
- Deprecate reports/get_devices