### PR TITLE
Spec update 11/12/2020

### DIFF
--- a/api_proxy_dev_check_api_v2_service.stone
+++ b/api_proxy_dev_check_api_v2_service.stone
@@ -10,8 +10,8 @@ route user (EchoArg, EchoResult, Void)
 
     attrs
         allow_app_folder_app = true
-        is_preview = true
         auth = "user"
+        is_preview = true
 
 route app (EchoArg, EchoResult, Void)
     "This endpoint performs App Authentication, validating the supplied app key and secret,
@@ -22,6 +22,6 @@ route app (EchoArg, EchoResult, Void)
 
     attrs
         allow_app_folder_app = true
-        is_preview = true
         auth = "app"
+        is_preview = true
 

--- a/common.stone
+++ b/common.stone
@@ -22,7 +22,7 @@ alias NamePart = String(pattern="[^\/:?*<>\"|]*", min_length=1, max_length=100)
 alias OptionalNamePart = String(pattern="[^\/:?*<>\"|]*", max_length=100)
 
 # We don't limit the length because it's always generated from the first & last names.
-alias DisplayName = String(pattern="[^\/:?*<>\"|]*", min_length=1)
+alias DisplayName = String(pattern="[^\/:?*<>\"|]*")
 
 # There are some existing accounts with special characters in their names. Though we don't allow such special characters
 # being used through UI, it's still possible to use them right now through some endpoints. This alias should be used in

--- a/team_log_generated.stone
+++ b/team_log_generated.stone
@@ -3648,6 +3648,18 @@ struct PasswordResetDetails
 struct PasswordResetAllDetails
     "Reset all team member passwords."
 
+struct ClassificationCreateReportDetails
+    "Created Classification report."
+
+struct ClassificationCreateReportFailDetails
+    "Couldn't create Classification report."
+
+    failure_reason team.TeamReportFailureReason
+        "Failure reason."
+
+    example default
+        failure_reason = temporary_error
+
 struct EmmCreateExceptionsReportDetails
     "Created EMM-excluded users report."
 
@@ -6352,6 +6364,8 @@ union EventDetails
     password_change_details PasswordChangeDetails
     password_reset_details PasswordResetDetails
     password_reset_all_details PasswordResetAllDetails
+    classification_create_report_details ClassificationCreateReportDetails
+    classification_create_report_fail_details ClassificationCreateReportFailDetails
     emm_create_exceptions_report_details EmmCreateExceptionsReportDetails
     emm_create_usage_report_details EmmCreateUsageReportDetails
     export_members_report_details ExportMembersReportDetails
@@ -7754,6 +7768,18 @@ struct PasswordResetAllType
 
     example default
         description = "(passwords) Reset all team member passwords"
+
+struct ClassificationCreateReportType
+    description String
+
+    example default
+        description = "(reports) Created Classification report"
+
+struct ClassificationCreateReportFailType
+    description String
+
+    example default
+        description = "(reports) Couldn't create Classification report"
 
 struct EmmCreateExceptionsReportType
     description String
@@ -9685,6 +9711,10 @@ union EventType
         "(passwords) Reset password"
     password_reset_all PasswordResetAllType
         "(passwords) Reset all team member passwords"
+    classification_create_report ClassificationCreateReportType
+        "(reports) Created Classification report"
+    classification_create_report_fail ClassificationCreateReportFailType
+        "(reports) Couldn't create Classification report"
     emm_create_exceptions_report EmmCreateExceptionsReportType
         "(reports) Created EMM-excluded users report"
     emm_create_usage_report EmmCreateUsageReportType
@@ -10587,6 +10617,10 @@ union EventTypeArg
         "(passwords) Reset password"
     password_reset_all
         "(passwords) Reset all team member passwords"
+    classification_create_report
+        "(reports) Created Classification report"
+    classification_create_report_fail
+        "(reports) Couldn't create Classification report"
     emm_create_exceptions_report
         "(reports) Created EMM-excluded users report"
     emm_create_usage_report


### PR DESCRIPTION
Change Notes:

Common Namespace
- DisplayName validation pattern is updated

team_log_generated Namespace
- Add ClassificationCreateReportDetails struct
- Add ClassificationCreateReportFailDetails struct
- Update EventDetails union to include ClassificationCreateReportDetails and ClassificationCreateReportFailDetails
- Add ClassificationCreateReportType struct
- Add ClassificationCreateReportFailType struct
- Update EventType union to include ClassificationCreateReportType and ClassificationCreateReportFailType
- Update EventTypeArg union to include classification_create_report and classification_create_report_fail