### PR TITLE
Spec Update 05/18/2022

### DIFF
--- a/files.stone
+++ b/files.stone
@@ -677,7 +677,9 @@ route download_zip (DownloadZipArg, DownloadZipResult, DownloadZipError)
     "Download a folder from the user's Dropbox, as a zip file. The folder must be less than 20 GB
     in size and any single file within must be less than 4 GB in size. The resulting zip must have
     fewer than 10,000 total file and folder entries, including the top level folder. The input
-    cannot be a single file."
+    cannot be a single file.
+
+    Note: this endpoint does not support HTTP range requests."
 
     attrs
         host = "content"
@@ -1158,6 +1160,10 @@ struct UploadArg extends CommitInfo
         "A hash of the file content uploaded in this call. If provided and the uploaded content
         does not match this hash, an error will be returned. For more information see our
         :link:`Content hash https://www.dropbox.com/developers/reference/content-hash` page."
+
+    example default
+        path = "/Homework/math/Matrices.txt"
+        content_hash = null
 
 route upload (UploadArg, FileMetadata, UploadError)
     "Create a new file with the contents provided in the request.

--- a/shared_links.stone
+++ b/shared_links.stone
@@ -266,6 +266,7 @@ route get_shared_link_metadata(GetSharedLinkMetadataArg, SharedLinkMetadata, Sha
     "Get the shared link's metadata."
 
     attrs
+        auth = "app, user"
         allow_app_folder_app = true
         scope = "sharing.read"
 

--- a/team_folders.stone
+++ b/team_folders.stone
@@ -93,7 +93,7 @@ route team_folder/create(TeamFolderCreateArg, TeamFolderMetadata, TeamFolderCrea
 
     attrs
         auth = "team"
-        scope = "team_data.team_space"
+        scope = "team_data.content.write"
 
 struct TeamFolderCreateArg
     name String
@@ -127,7 +127,7 @@ route team_folder/rename(TeamFolderRenameArg, TeamFolderMetadata, TeamFolderRena
 
     attrs
         auth = "team"
-        scope = "team_data.team_space"
+        scope = "team_data.content.write"
 
 struct TeamFolderRenameArg extends TeamFolderIdArg
     name String
@@ -155,7 +155,7 @@ route team_folder/list(TeamFolderListArg, TeamFolderListResult, TeamFolderListEr
     Permission : Team member file access."
     attrs
         auth = "team"
-        scope = "team_data.team_space"
+        scope = "team_data.content.read"
 
 struct TeamFolderListArg
     limit UInt32(min_value=1, max_value=1000) = 1000
@@ -195,7 +195,7 @@ route team_folder/list/continue(TeamFolderListContinueArg, TeamFolderListResult,
 
     attrs
         auth = "team"
-        scope = "team_data.team_space"
+        scope = "team_data.content.read"
 
 struct TeamFolderListContinueArg
     cursor String
@@ -219,7 +219,7 @@ route team_folder/get_info(TeamFolderIdListArg, List(TeamFolderGetInfoItem), Voi
 
     attrs
         auth = "team"
-        scope = "team_data.team_space"
+        scope = "team_data.content.read"
 
 union_closed TeamFolderGetInfoItem
     id_not_found String
@@ -239,7 +239,7 @@ route team_folder/activate(TeamFolderIdArg, TeamFolderMetadata, TeamFolderActiva
 
     attrs
         auth = "team"
-        scope = "team_data.team_space"
+        scope = "team_data.content.write"
 
 union TeamFolderActivateError extends BaseTeamFolderError
     ""
@@ -256,7 +256,7 @@ route team_folder/archive(TeamFolderArchiveArg, TeamFolderArchiveLaunch, TeamFol
 
     attrs
         auth = "team"
-        scope = "team_data.team_space"
+        scope = "team_data.content.write"
 
 struct TeamFolderArchiveArg extends TeamFolderIdArg
     force_async_off Boolean = false
@@ -285,7 +285,7 @@ route team_folder/archive/check(async.PollArg, TeamFolderArchiveJobStatus, async
 
     attrs
         auth = "team"
-        scope = "team_data.team_space"
+        scope = "team_data.content.write"
 
 union_closed TeamFolderArchiveJobStatus extends async.PollResultBase
     complete TeamFolderMetadata
@@ -308,7 +308,7 @@ route team_folder/permanently_delete(TeamFolderIdArg, Void, TeamFolderPermanentl
 
     attrs
         auth = "team"
-        scope = "team_data.team_space"
+        scope = "team_data.content.write"
 
 union TeamFolderPermanentlyDeleteError extends BaseTeamFolderError
     ""
@@ -338,4 +338,4 @@ route team_folder/update_sync_settings(TeamFolderUpdateSyncSettingsArg, TeamFold
 
     attrs
         auth = "team"
-        scope = "team_data.team_space"
+        scope = "team_data.content.write"

--- a/team_legal_holds.stone
+++ b/team_legal_holds.stone
@@ -116,7 +116,7 @@ route legal_holds/create_policy(LegalHoldsPolicyCreateArg, LegalHoldsPolicyCreat
 
     attrs
         auth = "team"
-        scope = "team_data.member"
+        scope = "team_data.governance.write"
 
 #
 # route legal_holds/get_policy
@@ -142,7 +142,7 @@ route legal_holds/get_policy(LegalHoldsGetPolicyArg, LegalHoldsGetPolicyResult, 
 
     attrs
         auth = "team"
-        scope = "team_data.member"
+        scope = "team_data.governance.write"
 
 
 #
@@ -173,7 +173,7 @@ route legal_holds/list_policies(LegalHoldsListPoliciesArg, LegalHoldsListPolicie
 
     attrs
         auth = "team"
-        scope = "team_data.member"
+        scope = "team_data.governance.write"
 
 
 #
@@ -254,7 +254,7 @@ route legal_holds/list_held_revisions(LegalHoldsListHeldRevisionsArg, LegalHolds
 
     attrs
         auth = "team"
-        scope = "team_data.member"
+        scope = "team_data.governance.write"
 
 
 #
@@ -286,7 +286,7 @@ route legal_holds/list_held_revisions_continue(LegalHoldsListHeldRevisionsContin
 
     attrs
         auth = "team"
-        scope = "team_data.member"
+        scope = "team_data.governance.write"
 
 #
 # route legal_holds/update_policy
@@ -334,7 +334,7 @@ route legal_holds/update_policy(LegalHoldsPolicyUpdateArg, LegalHoldsPolicyUpdat
 
     attrs
         auth = "team"
-        scope = "team_data.member"
+        scope = "team_data.governance.write"
 
 #
 # route legal_holds/release_policy
@@ -362,4 +362,4 @@ route legal_holds/release_policy(LegalHoldsPolicyReleaseArg, Void, LegalHoldsPol
 
     attrs
         auth = "team"
-        scope = "team_data.member"
+        scope = "team_data.governance.write"

--- a/team_log_generated.stone
+++ b/team_log_generated.stone
@@ -221,16 +221,24 @@ struct AdminAlertingAlertConfiguration
         "Sensitivity level."
     recipients_settings RecipientsConfiguration?
         "Recipient settings."
+    text String?
+        "Text."
+    excluded_file_extensions String?
+        "Excluded file extensions."
 
     example default
         alert_state = off
         sensitivity_level = invalid
         recipients_settings = default
+        text = "abc"
+        excluded_file_extensions = "abc"
 
     example default2
         alert_state = off
         sensitivity_level = invalid
         recipients_settings = default2
+        text = "xyz"
+        excluded_file_extensions = "xyz"
 
 struct RecipientsConfiguration
     "Recipients Configuration"
@@ -774,6 +782,7 @@ union PlacementRestriction
     japan_only
     none
     uk_only
+    us_s3_only
 
 union PolicyType
     disposition


### PR DESCRIPTION
Change Notes:

files Namespace
- Update examples

shared_links Namespace
- Update get_shared_link_metadata route to include app and user auth

team_folders Namespace
- Update team_folder/create, team_folder/rename, team_folder/list, team_folder/list/continue, team_folder/get_info, team_folder/activate, team_folder/archive, team_folder/archive/check, team_folder/permanently_delete, team_folder/update_sync_settings routes to include updated scopes

team_legal_holds Namespace
- Update legal_holds/create_policy, legal_holds/get_policy, legal_holds/list_policies, legal_holds/list_held_revisions, legal_holds/list_held_revisions_continue, legal_holds/update_policy, legal_holds/release_policy routes to include updated scopes

team_log_generated Namespace
- Update AdminAlertingAlertConfiguration to include text and excluded_file_extensions
- Update PlacementRestriction to include us_s3_only
- Update examples