### PR TITLE
Update repository dispatch workflow action

### DIFF
--- a/.github/workflows/dispatch_spec_update.yml
+++ b/.github/workflows/dispatch_spec_update.yml
@@ -1,21 +1,37 @@
 name: Dispatch Spec Update
-on: 
+
+on:
   workflow_dispatch:
   push:
     branches:
       - main
 
+permissions: {}
+
 jobs:
-  Dispatch:
+  dispatch:
+    name: Dispatch spec update to ${{ matrix.repository }}
     runs-on: ubuntu-latest
+
     strategy:
+      fail-fast: false
       matrix:
-        repository: ['dropbox/dropbox-sdk-python', 'dropbox/dropbox-sdk-js', 'dropbox/dropbox-sdk-dotnet', 'dropbox/dropbox-api-v2-explorer']
+        repository:
+          - dropbox/dropbox-sdk-python
+          - dropbox/dropbox-sdk-js
+          - dropbox/dropbox-sdk-dotnet
+          - dropbox/dropbox-api-v2-explorer
+
     steps:
-      - name: Dispatch Update
-        uses: peter-evans/repository-dispatch@v1
+      - name: Dispatch spec update
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.SPEC_UPDATE_TOKEN }}
           repository: ${{ matrix.repository }}
           event-type: spec_update
-      
+          client-payload: >-
+            {
+              "repository": "${{ github.repository }}",
+              "ref": "${{ github.ref }}",
+              "sha": "${{ github.sha }}"
+            }


### PR DESCRIPTION
Hey @dropbox, 

This updates the spec dispatch workflow to use `peter-evans/repository-dispatch@v4` instead of the older v1 action. The workflow still dispatches the same `spec_update` event to the existing downstream repositories, but now explicitly disables default `GITHUB_TOKEN` permissions because remote dispatches are authenticated with `SPEC_UPDATE_TOKEN`.

Worth noting that it also sets `fail-fast: false` for the repository matrix so one failed downstream dispatch does not cancel the remaining dispatch attempts, and adds a small `client-payload` containing the source repository, ref, and commit SHA for downstream workflows that want to inspect where the spec update came from.

```yaml
permissions: {}

strategy:
  fail-fast: false
  matrix:
    repository:
      - dropbox/dropbox-sdk-python
      - dropbox/dropbox-sdk-js
      - dropbox/dropbox-sdk-dotnet
      - dropbox/dropbox-api-v2-explorer

steps:
  - name: Dispatch spec update
    uses: peter-evans/repository-dispatch@v4
    with:
      token: ${{ secrets.SPEC_UPDATE_TOKEN }}
      repository: ${{ matrix.repository }}
      event-type: spec_update
      client-payload: >-
        {
          "repository": "${{ github.repository }}",
          "ref": "${{ github.ref }}",
          "sha": "${{ github.sha }}"
        }
```
Cheers,
Michael Mendy