### PR TITLE
Spec Update 06/05/2026

### DIFF
--- a/account.stone
+++ b/account.stone
@@ -3,16 +3,8 @@ namespace account
 import account_id
 import common
 
-route get_photo (AccountPhotoGetArg, AccountPhotoGetResult, AccountPhotoGetError)
-    "This lovely endpoint gets the account photo of a given user."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        host = "content"
-        scope = "account_info.read"
-        select_admin_mode = "whole_team"
-        style = "download"
+union DeleteProfilePhotoError
+    "This union is empty. The comment here is intentionally emitted to avoid indentation issues with Stone."
 
 
 union PhotoSourceArg
@@ -85,10 +77,35 @@ struct AccountPhotoGetResult
     example default
         content_type = "image/jpeg"
 
+struct DeleteProfilePhotoArg
+    "This struct is empty. The comment here is intentionally emitted to avoid indentation issues with Stone."
+
+struct DeleteProfilePhotoResult
+    "This struct is empty. The comment here is intentionally emitted to avoid indentation issues with Stone."
+
 route set_profile_photo (SetProfilePhotoArg, SetProfilePhotoResult, SetProfilePhotoError)
     "Sets a user's profile photo."
 
     attrs
         auth = "user"
         scope = "account_info.write"
+
+route delete_profile_photo (DeleteProfilePhotoArg, DeleteProfilePhotoResult, DeleteProfilePhotoError)
+    "Deletes the current user's profile photo."
+
+    attrs
+        auth = "user"
+        scope = "account_info.write"
+
+
+route get_photo (AccountPhotoGetArg, AccountPhotoGetResult, AccountPhotoGetError)
+    "This lovely endpoint gets the account photo of a given user."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        host = "content"
+        scope = "account_info.read"
+        select_admin_mode = "whole_team"
+        style = "download"
 

--- a/async.stone
+++ b/async.stone
@@ -25,7 +25,7 @@ union_closed LaunchEmptyResult extends LaunchResultBase
 
     example complete
         complete = null
-    
+
     example async_job_id
         async_job_id = "34g93hh34h04y384084"
 
@@ -54,7 +54,7 @@ union_closed PollEmptyResult extends PollResultBase
 
     example complete
         complete = null
-    
+
     example in_progress
         in_progress = null
 

--- a/check.stone
+++ b/check.stone
@@ -2,29 +2,6 @@ namespace check
 
 import common
 
-union EchoError
-    "EchoError contains the error returned from the Dropbox servers."
-    user_requested
-        "The request was successful."
-
-
-struct EchoArg
-    "Contains the arguments to be sent to the Dropbox servers."
-    query String(max_length=500) = ""
-        "The string that you'd like to be echoed back to you."
-
-    example default
-        query = "foo"
-
-struct EchoResult
-    "EchoResult contains the result returned from the Dropbox servers."
-    result String = ""
-        "If everything worked correctly, this would be the same as query."
-
-    example default
-        result = "foo"
-
-
 route user (EchoArg, EchoResult, EchoError)
     "This endpoint performs User Authentication, validating the supplied access token,
     and returns the supplied string, to allow you to test your code and connection to the
@@ -49,4 +26,27 @@ route app (EchoArg, EchoResult, EchoError)
         allow_app_folder_app = true
         auth = "app"
         is_preview = true
+
+
+union EchoError
+    "EchoError contains the error returned from the Dropbox servers."
+    user_requested
+        "The request was successful."
+
+
+struct EchoArg
+    "Contains the arguments to be sent to the Dropbox servers."
+    query String(max_length=500) = ""
+        "The string that you'd like to be echoed back to you."
+
+    example default
+        query = "foo"
+
+struct EchoResult
+    "EchoResult contains the result returned from the Dropbox servers."
+    result String = ""
+        "If everything worked correctly, this would be the same as query."
+
+    example default
+        result = "foo"
 

--- a/common.stone
+++ b/common.stone
@@ -1,15 +1,5 @@
 namespace common
 
-# Annotates fields to serialize a subset of total fields, depending on caller type
-
-# Annotates fields to redact information before storing in logs
-
-# Annotates fields for documentation changes
-
-alias DropboxTimestamp = Timestamp("%Y-%m-%dT%H:%M:%SZ")
-
-alias Date = Timestamp("%Y-%m-%d")
-
 alias EmailAddress = String(max_length=255, pattern="^['#&A-Za-z0-9._%+-]+@[A-Za-z0-9-][A-Za-z0-9.-]*\\.[A-Za-z]{2,15}$")
 
 alias NamePart = String(max_length=50, min_length=1, pattern="[^\/:?*<>\"|]*")
@@ -84,3 +74,15 @@ union PathRootError
         "You don't have permission to access the namespace id in Dropbox-API-Path-Root
         header."
 
+
+# Annotates fields to serialize a subset of total fields, depending on caller type
+
+# Annotates fields to redact information before storing in logs
+
+# Annotates fields for documentation changes
+annotation Deprecated = Deprecated()
+annotation Preview = Preview()
+
+alias DropboxTimestamp = Timestamp("%Y-%m-%dT%H:%M:%SZ")
+
+alias Date = Timestamp("%Y-%m-%d")

--- a/file_properties.stone
+++ b/file_properties.stone
@@ -1,6 +1,7 @@
 namespace file_properties
     "This namespace contains helpers for property and template metadata endpoints.
 
+
     These endpoints enable you to tag arbitrary key/value data to Dropbox files.
 
 
@@ -27,9 +28,9 @@ namespace file_properties
     when the app is linked with the owner of the template (either a user or team).
 
 
-    User-owned templates are accessed via the user-auth file_properties/templates/*_for_user endpoints, while
-    team-owned templates are accessed via the team-auth file_properties/templates/*_for_team endpoints. Properties
-    associated with either type of template can be accessed via the user-auth properties/* endpoints.
+    User-owned templates are accessed via the user-auth `file_properties/templates/*_for_user` endpoints, while
+    team-owned templates are accessed via the team-auth `file_properties/templates/*_for_team` endpoints. Properties
+    associated with either type of template can be accessed via the user-auth `properties/*` endpoints.
 
 
     Finally, properties can be accessed from a number of endpoints that return metadata, including

--- a/file_requests.stone
+++ b/file_requests.stone
@@ -121,7 +121,7 @@ struct FileRequestDeadline
 
     example deadline
         deadline = "2020-10-12T17:00:00Z"
-    
+
     example deadline_with_grace_period
         deadline = "2020-10-12T17:00:00Z"
         allow_late_uploads = seven_days
@@ -165,7 +165,7 @@ struct FileRequest
         is_open = true
         file_count = 3
         description = "Please submit your homework here."
-    
+
     example with_deadline
         id = "BAJ7IrRGicQKGToykQdB"
         url = "https://www.dropbox.com/request/BAJ7IrRGjcQKGToykQdB"
@@ -175,7 +175,7 @@ struct FileRequest
         deadline = deadline
         is_open = true
         file_count = 105
-    
+
     example with_no_deadline
         id = "rxwMPvK3ATTa0VxOJu5T"
         url = "https://www.dropbox.com/request/rxwMPvK3ATTa0VxOJu5T"

--- a/files.stone
+++ b/files.stone
@@ -6,41 +6,33 @@ import common
 import file_properties
 import users_common
 
-route search (SearchArg, SearchResult, SearchError) deprecated by search:2
-    "Searches for files and folders.
-
-    Note: Recent changes will be reflected in search results within a few seconds
-    and older revisions of existing files may still match your query for up to a few days."
-
-    attrs
-        allow_app_folder_app = true
-        scope = "files.metadata.read"
-
 route search:2 (SearchV2Arg, SearchV2Result, SearchError)
     "Searches for files and folders.
-
     Note: :route:`search:2` along with :route:`search/continue:2` can only be used to
     retrieve a maximum of 10,000 matches.
-
     Recent changes may not immediately be reflected in search results due to a short delay in indexing.
     Duplicate results may be returned across pages. Some results may not be returned."
 
     attrs
         allow_app_folder_app = true
+        auth = "app, user"
         scope = "files.metadata.read"
 
 route search/continue:2 (SearchV2ContinueArg, SearchV2Result, SearchError)
     "Fetches the next page of search results returned from :route:`search:2`.
-
     Note: :route:`search:2` along with :route:`search/continue:2` can only be used to
     retrieve a maximum of 10,000 matches.
-
     Recent changes may not immediately be reflected in search results due to a short delay in indexing.
     Duplicate results may be returned across pages. Some results may not be returned."
 
     attrs
         allow_app_folder_app = true
+        auth = "app, user"
         scope = "files.metadata.read"
+
+
+alias TagText = String(max_length=32, min_length=1, pattern="[\\w]+")
+
 
 union Tag
     "Tag that can be added in multiple ways."
@@ -134,785 +126,6 @@ route tags/get (GetTagsArg, GetTagsResult, BaseTagError)
         auth = "user"
         is_preview = true
         scope = "files.metadata.read"
-
-
-alias TagText = String(max_length=32, min_length=1, pattern="[\\w]+")
-
-
-route upload_session/start_batch (UploadSessionStartBatchArg, UploadSessionStartBatchResult, Void)
-    "Start a batch of upload sessions. See :route:`upload_session/start`. Calls to this endpoint will count
-    as data transport calls for any Dropbox Business teams with a limit on the number of data
-    transport calls allowed per month. For more information, see the Data transport limit page
-    https://www.dropbox.com/developers/reference/data-transport-limit."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-
-route create_folder (CreateFolderArg, FolderMetadata, CreateFolderError) deprecated
-    "Create a folder at a given path."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route create_folder:2 (CreateFolderArg, CreateFolderResult, CreateFolderError)
-    "Create a folder at a given path."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route delete (DeleteArg, Metadata, DeleteError) deprecated
-    "Delete the file or folder at a given path. If the path is a folder, all its contents will be
-    deleted too. A successful response indicates that the file or folder was deleted. The returned
-    metadata will be the corresponding FileMetadata or FolderMetadata for the item at time of
-    deletion, and not a DeletedMetadata object."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route delete:2 (DeleteArg, DeleteResult, DeleteError)
-    "Delete the file or folder at a given path. If the path is a folder, all its contents will be
-    deleted too. A successful response indicates that the file or folder was deleted. The returned
-    metadata will be the corresponding FileMetadata or FolderMetadata for the item at time of
-    deletion, and not a DeletedMetadata object."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route move (RelocationArg, Metadata, RelocationError) deprecated
-    "Move a file or folder to a different location in the user's Dropbox. If the source path is
-    a folder all its contents will be moved."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route move:2 (RelocationArg, RelocationResult, RelocationError)
-    "Move a file or folder to a different location in the user's Dropbox. If the source path is
-    a folder all its contents will be moved. Note that we do not currently support case-only
-    renaming."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-
-route export (ExportArg, ExportResult, ExportError)
-    "Export a file from a user's Dropbox. This route only supports exporting files that cannot be
-    downloaded directly and whose ExportResult.file_metadata has ExportInfo.export_as populated."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        host = "content"
-        is_preview = true
-        scope = "files.content.read"
-        select_admin_mode = "whole_team"
-        style = "download"
-
-
-route paper/create (PaperCreateArg, PaperCreateResult, PaperCreateError)
-    "Creates a new Paper doc with the provided content."
-
-    attrs
-        auth = "user"
-        is_preview = true
-        scope = "files.content.write"
-        style = "upload"
-
-route paper/update (PaperUpdateArg, PaperUpdateResult, PaperUpdateError)
-    "Updates an existing Paper doc with the provided content."
-
-    attrs
-        auth = "user"
-        is_preview = true
-        scope = "files.content.write"
-        style = "upload"
-
-
-route download (DownloadArg, FileMetadata, DownloadError)
-    "Download a file from a user's Dropbox."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        host = "content"
-        scope = "files.content.read"
-        select_admin_mode = "whole_team"
-        style = "download"
-
-
-route copy_reference/get (GetCopyReferenceArg, GetCopyReferenceResult, GetCopyReferenceError)
-    "Get a copy reference to a file or folder. This reference string can be used to save that
-    file or folder to another user's Dropbox by passing it to :route:`copy_reference/save`."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-
-route copy_reference/save (SaveCopyReferenceArg, SaveCopyReferenceResult, SaveCopyReferenceError)
-    "Save a copy reference returned by :route:`copy_reference/get` to the user's Dropbox."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-
-
-route download_zip (DownloadZipArg, DownloadZipResult, DownloadZipError)
-    "Download a folder from the user's Dropbox, as a zip file. The folder must be less than 20 GB
-    in size and any single file within must be less than 4 GB in size. The resulting zip must have
-    fewer than 10,000 total file and folder entries, including the top level folder. The input
-    cannot be a single file. Note: this endpoint does not support HTTP range requests."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        host = "content"
-        scope = "files.content.read"
-        style = "download"
-
-
-route get_preview (PreviewArg, FileMetadata, PreviewError)
-    "Get a preview for a file. Currently, PDF previews are generated for files with the following
-    extensions: .ai, .doc, .docm, .docx, .eps, .gdoc, .gslides, .odp, .odt, .pps, .ppsm, .ppsx,
-    .ppt, .pptm, .pptx, .rtf. HTML previews are generated for .csv, .ods, .xls, .xlsm, .gsheet,
-    .xlsx. Other formats will return an unsupported extension error."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        host = "content"
-        scope = "files.content.read"
-        select_admin_mode = "whole_team"
-        style = "download"
-
-route get_thumbnail (ThumbnailArg, FileMetadata, ThumbnailError)
-    "Get a thumbnail for an image. This method currently supports files with the following file
-    extensions: jpg, jpeg, png, tiff, tif, gif, webp, ppm and bmp. Photos that are larger than
-    20MB in size won't be converted to a thumbnail."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        host = "content"
-        scope = "files.content.read"
-        select_admin_mode = "whole_team"
-        style = "download"
-
-route get_thumbnail_batch (GetThumbnailBatchArg, GetThumbnailBatchResult, GetThumbnailBatchError)
-    "Get thumbnails for a list of images. We allow up to 25 thumbnails in a single batch. This
-    method currently supports files with the following file extensions: jpg, jpeg, png, tiff, tif,
-    gif, webp, ppm and bmp. Photos that are larger than 20MB in size won't be converted to a
-    thumbnail."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        host = "content"
-        scope = "files.content.read"
-        select_admin_mode = "whole_team"
-
-route get_thumbnail:2 (ThumbnailV2Arg, PreviewResult, ThumbnailV2Error)
-    "Get a thumbnail for an image. This method currently supports files with the following file
-    extensions: jpg, jpeg, png, tiff, tif, gif, webp, ppm and bmp. Photos that are larger than
-    20MB in size won't be converted to a thumbnail."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "app, user"
-        host = "content"
-        scope = "files.content.read"
-        select_admin_mode = "whole_team"
-        style = "download"
-
-
-route create_folder_batch (CreateFolderBatchArg, CreateFolderBatchLaunch, Void)
-    "Create multiple folders at once. This route is asynchronous for large batches, which returns
-    a job ID immediately and runs the create folder batch asynchronously. Otherwise, creates
-    the folders and returns the result synchronously for smaller inputs. You can force asynchronous
-    behaviour by using the CreateFolderBatchArg.force_async flag.  Use
-    :route:`create_folder_batch/check` to check the job status."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route create_folder_batch/check (async.PollArg, CreateFolderBatchJobStatus, async.PollError)
-    "Returns the status of an asynchronous job for :route:`create_folder_batch`. If success, it
-    returns list of result for each entry."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route delete_batch (DeleteBatchArg, DeleteBatchLaunch, Void)
-    "Delete multiple files/folders at once. This route is asynchronous, which returns a job ID
-    immediately and runs the delete batch asynchronously. Use :route:`delete_batch/check` to
-    check the job status."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route delete_batch/check (async.PollArg, DeleteBatchJobStatus, async.PollError)
-    "Returns the status of an asynchronous job for :route:`delete_batch`. If success, it returns
-    list of result for each entry."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route permanently_delete (DeleteArg, Void, DeleteError)
-    "Permanently delete the file or folder at a given path (see
-    https://www.dropbox.com/en/help/40). If the given file or folder is not yet deleted, this
-    route will first delete it. It is possible for this route to successfully delete, then fail
-    to permanently delete. Note: This endpoint is only available for Dropbox Business apps."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.permanent_delete"
-        select_admin_mode = "team_admin"
-
-route copy (RelocationArg, Metadata, RelocationError) deprecated
-    "Copy a file or folder to a different location in the user's Dropbox.
-    If the source path is a folder all its contents will be copied."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route copy:2 (RelocationArg, RelocationResult, RelocationError)
-    "Copy a file or folder to a different location in the user's Dropbox.
-    If the source path is a folder all its contents will be copied."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route copy_batch (RelocationBatchArg, RelocationBatchLaunch, Void) deprecated
-    "Copy multiple files or folders to different locations at once in the user's Dropbox.
-    This route will return job ID immediately and do the async copy job in background.
-    Please use :route:`copy_batch/check` to check the job status."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route copy_batch:2 (CopyBatchArg, RelocationBatchV2Launch, Void)
-    "Copy multiple files or folders to different locations at once in the user's Dropbox.
-    This route will replace :route:`copy_batch`. The main difference is this route will return
-    status for each entry, while :route:`copy_batch` raises failure if any entry fails. This
-    route will either finish synchronously, or return a job ID and do the async copy job in
-    background. Please use :route:`copy_batch/check:2` to check the job status."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route copy_batch/check (async.PollArg, RelocationBatchJobStatus, async.PollError) deprecated
-    "Returns the status of an asynchronous job for :route:`copy_batch:1`. If success, it returns
-    list of results for each entry."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route copy_batch/check:2 (async.PollArg, RelocationBatchV2JobStatus, async.PollError)
-    "Returns the status of an asynchronous job for :route:`copy_batch:2`. It returns list of
-    results for each entry."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route move_batch (RelocationBatchArg, RelocationBatchLaunch, Void) deprecated
-    "Move multiple files or folders to different locations at once in the user's Dropbox.
-    This route will return job ID immediately and do the async moving job in background.
-    Please use :route:`move_batch/check` to check the job status."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route move_batch:2 (MoveBatchArg, RelocationBatchV2Launch, Void)
-    "Move multiple files or folders to different locations at once in the user's Dropbox.
-    Note that we do not currently support case-only renaming. This route will replace
-    :route:`move_batch`. The main difference is this route will return status for each entry,
-    while :route:`move_batch` raises failure if any entry fails. This route will either finish
-    synchronously, or return a job ID and do the async move job in background. Please use
-    :route:`move_batch/check:2` to check the job status."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route move_batch/check (async.PollArg, RelocationBatchJobStatus, async.PollError) deprecated
-    "Returns the status of an asynchronous job for :route:`move_batch:1`. If success, it returns
-    list of results for each entry."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route move_batch/check:2 (async.PollArg, RelocationBatchV2JobStatus, async.PollError)
-    "Returns the status of an asynchronous job for :route:`move_batch:2`. It returns list of
-    results for each entry."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-
-route list_revisions (ListRevisionsArg, ListRevisionsResult, ListRevisionsError)
-    "Returns revisions for files based on a file path or a file id. The file path or file id is
-    identified from the latest file entry at the given file path or id. This end point allows
-    your app to query either by file path or file id by setting the mode parameter appropriately.
-    In the ListRevisionsMode.path (default) mode, all revisions at the same file path as the
-    latest file entry are returned. If revisions with the same file id are desired, then mode
-    must be set to ListRevisionsMode.id. The ListRevisionsMode.id mode is useful to retrieve
-    revisions for a given file across moves or renames."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.metadata.read"
-        select_admin_mode = "whole_team"
-
-route restore (RestoreArg, FileMetadata, RestoreError)
-    "Restore a specific revision of a file to the given path."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-
-route get_metadata (GetMetadataArg, Metadata, GetMetadataError)
-    "Returns the metadata for a file or folder.
-    Note: Metadata for the root folder is unsupported."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.metadata.read"
-        select_admin_mode = "whole_team"
-
-route list_folder (ListFolderArg, ListFolderResult, ListFolderError)
-    "Starts returning the contents of a folder. If the result's :field:`ListFolderResult.has_more`
-    field is true, call :route:`list_folder/continue` with the returned ListFolderResult.cursor to
-    retrieve more entries. If you're using ListFolderArg.recursive set to true to keep a local
-    cache of the contents of a Dropbox account, iterate through each entry in order and process
-    them as follows to keep your local state in sync: For each FileMetadata, store the new entry
-    at the given path in your local state. If the required parent folders don't exist yet, create
-    them. If there's already something else at the given path, replace it and remove all its
-    children. For each FolderMetadata, store the new entry at the given path in your local state.
-    If the required parent folders don't exist yet, create them. If there's already something else
-    at the given path, replace it but leave the children as they are. Check the new entry's
-    FolderSharingInfo.read_only and set all its children's read-only statuses to match. For each
-    DeletedMetadata, if your local state has something at the given path, remove it and all its
-    children. If there's nothing at the given path, ignore this entry. Note: auth.RateLimitError
-    may be returned if multiple :route:`list_folder` or :route:`list_folder/continue` calls with same parameters
-    are made simultaneously by same API app for same user. If your app implements retry logic,
-    please hold off the retry until the previous request finishes."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "app, user"
-        scope = "files.metadata.read"
-        select_admin_mode = "whole_team"
-
-route list_folder/continue (ListFolderContinueArg, ListFolderResult, ListFolderContinueError)
-    "Once a cursor has been retrieved from :route:`list_folder`, use this to paginate through all
-    files and retrieve updates to the folder, following the same rules as documented for
-    :route:`list_folder`."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "app, user"
-        scope = "files.metadata.read"
-        select_admin_mode = "whole_team"
-
-route list_folder/get_latest_cursor (ListFolderArg, ListFolderGetLatestCursorResult, ListFolderError)
-    "A way to quickly get a cursor for the folder's state. Unlike :route:`list_folder`,
-    :route:`list_folder/get_latest_cursor` doesn't return any entries. This endpoint is for app which
-    only needs to know about new files and modifications and doesn't need to know about files
-    that already exist in Dropbox."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.metadata.read"
-        select_admin_mode = "whole_team"
-
-route list_folder/longpoll (ListFolderLongpollArg, ListFolderLongpollResult, ListFolderLongpollError)
-    "A longpoll endpoint to wait for changes on an account. In conjunction with :route:`list_folder/continue`,
-    this call gives you a low-latency way to monitor an account for file changes. The connection
-    will block until there are changes available or a timeout occurs. This endpoint is useful
-    mostly for client-side apps."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "noauth"
-        host = "notify"
-        scope = "files.metadata.read"
-        select_admin_mode = "whole_team"
-
-route alpha/get_metadata (AlphaGetMetadataArg, Metadata, AlphaGetMetadataError) deprecated
-    "Returns the metadata for a file or folder. This is an alpha endpoint compatible
-    with the properties API. Note: Metadata for the root folder is unsupported."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        is_preview = true
-        scope = "files.metadata.read"
-
-
-route upload_session/finish_batch (UploadSessionFinishBatchArg, UploadSessionFinishBatchLaunch, Void) deprecated
-    "This route helps you commit many files at once into a user's Dropbox. Use :route:`upload_session/start`
-    and :route:`upload_session/append:2` to upload file contents. We recommend uploading many files in
-    parallel to increase throughput. Once the file contents have been uploaded, rather than
-    calling :route:`upload_session/finish`, use this route to finish all your upload sessions in a single
-    request. :field:`UploadSessionStartArg.close` or :field:`UploadSessionAppendArg.close` needs to be true for
-    the last :route:`upload_session/start` or :route:`upload_session/append:2` call. The maximum size of a file
-    one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248) bytes. This route will
-    return a job_id immediately and do the async commit job in background. Use
-    :route:`upload_session/finish_batch/check` to check the job status. For the same account, this route
-    should be executed serially. That means you should not start the next job before current job
-    finishes. We allow up to 1000 entries in a single request. Calls to this endpoint will count
-    as data transport calls for any Dropbox Business teams with a limit on the number of data
-    transport calls allowed per month. For more information, see the Data transport limit page
-    https://www.dropbox.com/developers/reference/data-transport-limit."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route upload_session/finish_batch:2 (UploadSessionFinishBatchArg, UploadSessionFinishBatchResult, Void)
-    "This route helps you commit many files at once into a user's Dropbox. Use :route:`upload_session/start`
-    and :route:`upload_session/append:2` to upload file contents. We recommend uploading many files in
-    parallel to increase throughput. Once the file contents have been uploaded, rather than
-    calling :route:`upload_session/finish`, use this route to finish all your upload sessions in a single
-    request. :field:`UploadSessionStartArg.close` or :field:`UploadSessionAppendArg.close` needs to be true for
-    the last :route:`upload_session/start` or :route:`upload_session/append:2` call of each upload session. The
-    maximum size of a file one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248)
-    bytes. We allow up to 1000 entries in a single request. Calls to this endpoint will count
-    as data transport calls for any Dropbox Business teams with a limit on the number of data
-    transport calls allowed per month. For more information, see the Data transport limit page
-    https://www.dropbox.com/developers/reference/data-transport-limit."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-route upload_session/finish_batch/check (async.PollArg, UploadSessionFinishBatchJobStatus, async.PollError)
-    "Returns the status of an asynchronous job for :route:`upload_session/finish_batch`. If success, it
-    returns list of result for each entry."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-
-
-route get_temporary_link (GetTemporaryLinkArg, GetTemporaryLinkResult, GetTemporaryLinkError)
-    "Get a temporary link to stream content of a file. This link will expire in four hours and
-    afterwards you will get 410 Gone. This URL should not be used to display content directly
-    in the browser. The Content-Type of the link is determined automatically by the file's mime type."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.read"
-
-
-route properties/add (file_properties.AddPropertiesArg, Void, file_properties.AddPropertiesError) deprecated
-    "Add property groups to a Dropbox file. See templates/add_for_user or
-    templates/add_for_team to create new templates."
-
-    attrs
-        auth = "user"
-        scope = "files.metadata.write"
-
-route properties/update (file_properties.UpdatePropertiesArg, Void, file_properties.UpdatePropertiesError) deprecated
-    "Add, update or remove properties associated with the supplied file and templates.
-    This endpoint should be used instead of properties/overwrite when property groups
-    are being updated via a \"delta\" instead of overwriting all properties of a file."
-
-    attrs
-        auth = "user"
-        scope = "files.metadata.write"
-
-route properties/overwrite (file_properties.OverwritePropertyGroupArg, Void, file_properties.InvalidPropertyGroupError) deprecated
-    "Overwrite property groups associated with a file. This endpoint should be used
-    instead of properties/update when property groups are being overwritten rather
-    than updated via a \"delta\"."
-
-    attrs
-        auth = "user"
-        scope = "files.metadata.write"
-
-
-route save_url (SaveUrlArg, SaveUrlResult, SaveUrlError)
-    "Save the data from a specified URL into a file in user's Dropbox.
-    Note that the transfer from the URL must complete within 15 minutes, or the
-    operation will time out and the job will fail."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-
-route save_url/check_job_status (async.PollArg, SaveUrlJobStatus, async.PollError)
-    "Check the status of a :route:`save_url` job."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-
-
-route upload (UploadArg, FileMetadata, UploadError)
-    "Create a new file with the contents provided in the request. Do not use this to upload a
-    file larger than 150 MiB. Instead, create an upload session with :route:`upload_session/start`.
-    Calls to this endpoint will count as data transport calls for any Dropbox Business teams
-    with a limit on the number of data transport calls allowed per month. For more information,
-    see the Data transport limit page https://www.dropbox.com/developers/reference/data-transport-limit."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        host = "content"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-        style = "upload"
-
-route upload_session/start (UploadSessionStartArg, UploadSessionStartResult, UploadSessionStartError)
-    "Upload sessions allow you to upload a single file in one or more requests, for example where
-    the size of the file is greater than 150 MiB. This call starts a new upload session with the
-    given data. You can then use :route:`upload_session/append:2` or :route:`upload_session/append_batch` to add
-    more data, then :route:`upload_session/finish` or :route:`upload_session/finish_batch:2` to save all the data to
-    a file in Dropbox. A single request should not upload more than 150 MiB. The maximum size of
-    a file one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248) bytes.
-    An upload session can be used for a maximum of 7 days. Attempting to use a
-    :field:`UploadSessionStartResult.session_id` with :route:`upload_session/append:2` or other upload session
-    routes more than 7 days after its creation will return :field:`UploadSessionLookupError.not_found`.
-    Calls to this endpoint will count as data transport calls for any Dropbox Business teams with a
-    limit on the number of data transport calls allowed per month. For more information, see the
-    Data transport limit page https://www.dropbox.com/developers/reference/data-transport-limit.
-    By default, upload sessions require you to send content of the file in sequential order via
-    consecutive :route:`upload_session/start`, :route:`upload_session/append:2`, and :route:`upload_session/finish` calls
-    (or their batch variants). For better performance, you can optionally set
-    :field:`UploadSessionStartArg.session_type` to :field:`UploadSessionType.concurrent` to start a concurrent
-    upload session. Concurrent upload sessions may upload file data in concurrent
-    :route:`upload_session/append:2` requests, with a few caveats. After all of the requests are complete,
-    finish the session with :route:`upload_session/finish` as normal. You can not send data in a
-    :route:`upload_session/start` or :route:`upload_session/finish` call, only with :route:`upload_session/append:2` or
-    :route:`upload_session/append_batch`. Also, the length of the uploaded data in a call to
-    :route:`upload_session/append:2` or :route:`upload_session/append_batch` must be a multiple of 2^22 (4,194,304)
-    bytes, except for the final append request with :field:`UploadSessionAppendArg.close` or
-    :field:`UploadSessionAppendBatchArgEntry.close` set to true that may contain any remaining data."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        host = "content"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-        style = "upload"
-
-route upload_session/append (UploadSessionCursor, Void, UploadSessionAppendError) deprecated
-    "Append more data to an upload session. A single request should not upload more than 150 MiB.
-    The maximum size of a file one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248) bytes.
-    Calls to this endpoint will count as data transport calls for any Dropbox Business teams with a
-    limit on the number of data transport calls allowed per month. For more information, see the
-    Data transport limit page https://www.dropbox.com/developers/reference/data-transport-limit."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        host = "content"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-        style = "upload"
-
-route upload_session/append:2 (UploadSessionAppendArg, Void, UploadSessionAppendError)
-    "Append more data to an upload session. When the parameter close is set, this call will close
-    the session. A single request should not upload more than 150 MiB. The maximum size of a file
-    one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248) bytes. Calls to this
-    endpoint will count as data transport calls for any Dropbox Business teams with a limit on the
-    number of data transport calls allowed per month. For more information, see the Data transport
-    limit page https://www.dropbox.com/developers/reference/data-transport-limit."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        host = "content"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-        style = "upload"
-
-route upload_session/append_batch (UploadSessionAppendBatchArg, UploadSessionAppendBatchResult, UploadSessionAppendBatchError)
-    "Append more data to multiple upload sessions. Each piece of file content to append to each
-    upload session should be concatenated in the request body, in the order delineated by
-    :field:`UploadSessionAppendBatchArg.entries` and their individual lengths indicated by
-    :field:`UploadSessionAppendBatchArgEntry.length`. A single request should not upload more than 150 MiB.
-    The maximum size of a file one can upload to an upload session is
-    2^41 - 2^22 (2,199,019,061,248) bytes. Calls to this endpoint will count as data transport
-    calls for any Dropbox Business teams with a limit on the number of data transport calls allowed
-    per month. For more information, see the Data transport limit page
-    https://www.dropbox.com/developers/reference/data-transport-limit."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        host = "content"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-        style = "upload"
-
-route upload_session/finish (UploadSessionFinishArg, FileMetadata, UploadSessionFinishError)
-    "Finish an upload session and save the uploaded data to the given file path. A single request
-    should not upload more than 150 MiB. The maximum size of a file one can upload to an upload
-    session is 2^41 - 2^22 (2,199,019,061,248) bytes. Calls to this endpoint will count as data
-    transport calls for any Dropbox Business teams with a limit on the number of data transport
-    calls allowed per month. For more information, see the Data transport limit page
-    https://www.dropbox.com/developers/reference/data-transport-limit."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        host = "content"
-        scope = "files.content.write"
-        select_admin_mode = "team_admin"
-        style = "upload"
-
-route alpha/upload (UploadArg, FileMetadata, UploadError) deprecated
-    "Create a new file with the contents provided in the request. Note that the behavior of this
-    alpha endpoint is unstable and subject to change. Do not use this to upload a file larger
-    than 150 MiB. Instead, create an upload session with :route:`upload_session/start`."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        host = "content"
-        is_preview = true
-        scope = "files.content.write"
-        style = "upload"
-
-
-route get_temporary_upload_link (GetTemporaryUploadLinkArg, GetTemporaryUploadLinkResult, Void)
-    "Get a one-time use temporary upload link to upload a file to a Dropbox location.  This
-    endpoint acts as a delayed upload(). The returned temporary upload link may be used to make
-    a POST request with the data to be uploaded. The upload will then be perfomed with the
-    CommitInfo previously provided to getTemporaryUploadLink() but evaluated only upon consumption.
-    Hence, errors stemming from invalid CommitInfo with respect to the state of the user's Dropbox
-    will only be communicated at consumption time. Additionally, these errors are surfaced as
-    generic HTTP 409 Conflict responses, potentially hiding issue details. The maximum temporary
-    upload link duration is 4 hours. Upon consumption or expiration, a new link will have to be
-    generated. Multiple links may exist for a specific upload path at any given time.  The POST
-    request on the temporary upload link must have its Content-Type set to
-    \"application/octet-stream\".  Example temporary upload link consumption request:  curl -X POST
-    https://content.dropboxapi.com/apitul/1/bNi2uIYF51cVBND --header
-    \"Content-Type: application/octet-stream\" --data-binary @local_file.txt  A successful temporary
-    upload link consumption request returns the content hash of the uploaded data in JSON format.
-    Example successful temporary upload link consumption response: {\"content-hash\":
-    \"599d71033d700ac892a0e48fa61b125d2f5994\"}  An unsuccessful temporary upload link consumption
-    request returns any of the following status codes:  HTTP 400 Bad Request: Content-Type is not
-    one of application/octet-stream and text/plain or request is invalid. HTTP 409 Conflict: The
-    temporary upload link does not exist or is currently unavailable, the upload failed, or
-    another error happened. HTTP 410 Gone: The temporary upload link is expired or consumed.
-    Example unsuccessful temporary upload link consumption response: Temporary upload link has
-    been recently consumed."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "files.content.write"
-
-
-route lock_file_batch (LockFileBatchArg, LockFileBatchResult, LockFileError)
-    "Lock the files at the given paths. A locked file will be writable only by the lock holder.
-    A successful response indicates that the file has been locked. Returns a list of the locked
-    file paths and their metadata after this operation."
-
-    attrs
-        auth = "user"
-        scope = "files.content.write"
-
-route unlock_file_batch (UnlockFileBatchArg, LockFileBatchResult, LockFileError)
-    "Unlock the files at the given paths. A locked file can only be unlocked by the lock holder
-    or, if a business account, a team admin. A successful response indicates that the file has
-    been unlocked. Returns a list of the unlocked file paths and their metadata after this
-    operation."
-
-    attrs
-        auth = "user"
-        scope = "files.content.write"
-        select_admin_mode = "whole_team"
-
-route get_file_lock_batch (LockFileBatchArg, LockFileBatchResult, LockFileError)
-    "Return the lock metadata for the given list of paths."
-
-    attrs
-        auth = "user"
-        scope = "files.content.read"
 
 
 alias CopyBatchArg = RelocationBatchArgBase
@@ -1065,6 +278,7 @@ union UploadSessionFinishError
     properties_error file_properties.InvalidPropertyGroupError
         "The supplied property group is invalid. The file has uploaded without property groups."
     too_many_shared_folder_targets
+        @common.Deprecated
         "The batch request commits files into too many different shared folders.
         Please limit your batch request to files contained in a single shared folder."
     too_many_write_operations
@@ -1235,10 +449,10 @@ union_closed WriteMode
 
     example default
         add = null
-    
+
     example overwriting
         overwrite = null
-    
+
     example with_revision
         update = "a1c10ce0dd78"
 
@@ -1274,11 +488,11 @@ struct CommitInfo
     example default
         path = "/Homework/math/Matrices.txt"
         autorename = true
-    
+
     example another
         path = "/Homework/math/Vectors.txt"
         autorename = true
-    
+
     example update
         path = "/Homework/math/Matrices.txt"
         mode = with_revision
@@ -1295,7 +509,7 @@ struct UploadSessionCursor
     example default
         session_id = "pid_upload_session:h-NtwvAdw3XDqqHmb0J2t0XfIaSnQw2Eor59pfZI9D_ZGNJ4Ew"
         offset = 0
-    
+
     example another
         session_id = "pid_upload_session:6MvrpirpGzvgtxdyRkiYzL4bpnd_xOuqWBBCdYBUiM7uQe2fPw"
         offset = 1073741824
@@ -1313,11 +527,11 @@ struct UploadSessionFinishArg
     example default
         cursor = default
         commit = default
-    
+
     example another
         cursor = another
         commit = another
-    
+
     example update
         cursor = default
         commit = update
@@ -1414,6 +628,7 @@ struct LockFileResult
     metadata Metadata
         "Metadata of the file."
     lock FileLock
+        @common.Deprecated
         "The file lock state after the operation."
 
     example default
@@ -1459,7 +674,7 @@ struct FolderSharingInfo extends SharingInfo
     example default
         read_only = false
         parent_shared_folder_id = "84528192421"
-    
+
     example shared_folder
         read_only = true
         shared_folder_id = "84528192421"
@@ -1559,6 +774,7 @@ struct Metadata
         to only the casing of paths won't be returned by :route:`list_folder/continue`. This field
         will be null if the file or folder is not mounted."
     parent_shared_folder_id common.SharedFolderId?
+        @common.Deprecated
         "Please use :field:`FileSharingInfo.parent_shared_folder_id`
         or :field:`FolderSharingInfo.parent_shared_folder_id` instead."
     preview_url String?
@@ -1566,10 +782,10 @@ struct Metadata
 
     example default
         file = default
-    
+
     example folder_metadata
         folder = default
-    
+
     example search_metadata
         file = search_file_metadata
 
@@ -1632,7 +848,7 @@ struct FileMetadata extends Metadata
         has_explicit_shared_members = false
         content_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         file_lock_info = default
-    
+
     example search_file_metadata
         id = "id:a4ayc_80_OEAAAAAAAAAXw"
         name = "Prime_Numbers.txt"
@@ -1651,6 +867,7 @@ struct FolderMetadata extends Metadata
     id Id
         "A unique identifier for the folder."
     shared_folder_id common.SharedFolderId?
+        @common.Deprecated
         "Please use :field:`sharing_info` instead."
     sharing_info FolderSharingInfo?
         "Set if the folder is contained in a shared folder or is a shared folder mount point."
@@ -1679,16 +896,30 @@ struct PreviewArg
     path ReadPath
         "The path of the file to preview."
     rev Rev?
+        @common.Deprecated
         "Please specify revision in :field:`path` instead."
 
     example default
         path = "/word.docx"
-    
+
     example id
         path = "id:a4ayc_80_OEAAAAAAAAAYa"
-    
+
     example rev
         path = "rev:a1c10ce0dd78"
+
+
+alias Path = String(pattern="/(.|[\\r\\n])*")
+
+struct HighlightSpan
+    highlight_str String
+        "String to be determined whether it should be highlighted or not."
+    is_highlighted Boolean
+        "The string should be highlighted or not."
+
+    example default
+        highlight_str = "test"
+        is_highlighted = false
 
 
 union_closed AlphaGetMetadataError extends GetMetadataError
@@ -1714,7 +945,7 @@ union CreateFolderBatchLaunch extends async.LaunchResultBase
 
     example complete
         complete = default
-    
+
     example async_job_id
         async_job_id = "34g93hh34h04y384084"
 
@@ -1733,6 +964,7 @@ union_closed CreateFolderError
 
 union DeleteBatchError
     too_many_write_operations
+        @common.Deprecated
         "Use :field:`DeleteError.too_many_write_operations`. :route:`delete_batch` now
         provides smaller granularity about which entry has failed because of this."
 
@@ -1752,7 +984,7 @@ union DeleteBatchLaunch extends async.LaunchResultBase
 
     example complete
         complete = default
-    
+
     example async_job_id
         async_job_id = "34g93hh34h04y384084"
 
@@ -1982,7 +1214,7 @@ union RelocationBatchLaunch extends async.LaunchResultBase
 
     example complete
         complete = default
-    
+
     example async_job_id
         async_job_id = "34g93hh34h04y384084"
 
@@ -2009,7 +1241,7 @@ union_closed RelocationBatchV2Launch extends async.LaunchResultBase
 
     example complete
         complete = default
-    
+
     example async_job_id
         async_job_id = "34g93hh34h04y384084"
 
@@ -2120,10 +1352,10 @@ union_closed SearchMode
 
     example default
         filename_and_content = null
-    
+
     example name_only
         filename = null
-    
+
     example deleted_names
         deleted_filename = null
 
@@ -2227,7 +1459,7 @@ union UploadSessionFinishBatchLaunch extends async.LaunchResultBase
 
     example complete
         complete = default
-    
+
     example async_job_id
         async_job_id = "34g93hh34h04y384084"
 
@@ -2257,16 +1489,17 @@ union UploadSessionType
 
 struct AlphaGetMetadataArg extends GetMetadataArg
     include_property_templates List(file_properties.TemplateId)?
+        @common.Deprecated
         "If set to a valid list of template IDs,
         :field:`FileMetadata.property_groups` is set for files with custom
         properties."
 
     example default
         path = "/Homework/math"
-    
+
     example id
         path = "id:a4ayc_80_OEAAAAAAAAAYa"
-    
+
     example rev
         path = "rev:a1c10ce0dd78"
 
@@ -2371,14 +1604,15 @@ struct DownloadArg
     path ReadPath
         "The path of the file to download."
     rev Rev?
+        @common.Deprecated
         "Please specify revision in :field:`path` instead."
 
     example default
         path = "/Homework/math/Prime_Numbers.txt"
-    
+
     example id
         path = "id:a4ayc_80_OEAAAAAAAAAYa"
-    
+
     example rev
         path = "rev:a1c10ce0dd78"
 
@@ -2388,10 +1622,10 @@ struct DownloadZipArg
 
     example default
         path = "/Homework/math"
-    
+
     example id
         path = "id:a4ayc_80_OEAAAAAAAAAYa"
-    
+
     example rev
         path = "rev:a1c10ce0dd78"
 
@@ -2413,7 +1647,7 @@ struct ExportArg
 
     example default
         path = "/Homework/math/Prime_Numbers.gsheet"
-    
+
     example id
         path = "id:a4ayc_80_OEAAAAAAAAAYa"
 
@@ -2486,10 +1720,10 @@ struct GetMetadataArg
 
     example default
         path = "/Homework/math"
-    
+
     example id
         path = "id:a4ayc_80_OEAAAAAAAAAYa"
-    
+
     example rev
         path = "rev:a1c10ce0dd78"
 
@@ -2563,6 +1797,7 @@ struct ListFolderArg
         performance issues or errors, especially when traversing folder structures with a large number of items.
         A workaround for such cases is to set :field:`ListFolderArg.recursive` to :val:`false` and traverse subfolders one at a time."
     include_media_info Boolean = false
+        @common.Deprecated
         "If true, :field:`FileMetadata.media_info` is set for photo and video. This parameter will no longer have an effect starting December 2, 2019."
     include_deleted Boolean = false
         "If true, the results will include entries for files and folders that used to exist but were deleted."
@@ -2789,6 +2024,7 @@ struct PreviewResult
 
 struct RelocationArg extends RelocationPath
     allow_shared_folder Boolean = false
+        @common.Deprecated
         "This flag has no effect."
     autorename Boolean = false
         "If there's a conflict, have the Dropbox server try to autorename
@@ -2803,6 +2039,7 @@ struct RelocationArg extends RelocationPath
 
 struct RelocationBatchArg extends RelocationBatchArgBase
     allow_shared_folder Boolean = false
+        @common.Deprecated
         "This flag has no effect."
     allow_ownership_transfer Boolean = false
         "Allow moves by owner even if it would result in an ownership transfer
@@ -2972,6 +2209,7 @@ struct SearchV2Arg
     match_field_options SearchMatchFieldOptions?
         "Options for search results match fields."
     include_highlights Boolean?
+        @common.Deprecated
         "Deprecated and moved this option to SearchMatchFieldOptions."
 
     example default
@@ -3021,11 +2259,11 @@ struct ThumbnailArg
     example default
         path = "/image.jpg"
         format = jpeg
-    
+
     example id
         path = "id:a4ayc_80_OEAAAAAAAAAYa"
         format = jpeg
-    
+
     example rev
         path = "rev:a1c10ce0dd78"
         format = jpeg
@@ -3104,7 +2342,7 @@ struct UploadSessionAppendBatchArg
 
     example default
         entries = [default]
-    
+
     example multiple
         entries = [default, another]
 
@@ -3122,7 +2360,7 @@ struct UploadSessionAppendBatchArgEntry
     example default
         cursor = default
         length = 12345
-    
+
     example another
         cursor = another
         length = 67890
@@ -3141,7 +2379,7 @@ struct UploadSessionFinishBatchArg
 
     example default
         entries = [default]
-    
+
     example multiple
         entries = [default, another]
 
@@ -3205,15 +2443,789 @@ struct UploadWriteFailed
         session and this ID may be used to retry the commit with :route:`upload_session/finish`."
 
 
-alias Path = String(pattern="/(.|[\\r\\n])*")
+route create_folder_batch (CreateFolderBatchArg, CreateFolderBatchLaunch, Void)
+    "Create multiple folders at once. This route is asynchronous for large batches, which returns
+    a job ID immediately and runs the create folder batch asynchronously. Otherwise, creates
+    the folders and returns the result synchronously for smaller inputs. You can force asynchronous
+    behaviour by using the CreateFolderBatchArg.force_async flag.  Use
+    :route:`create_folder_batch/check` to check the job status."
 
-struct HighlightSpan
-    highlight_str String
-        "String to be determined whether it should be highlighted or not."
-    is_highlighted Boolean
-        "The string should be highlighted or not."
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
 
-    example default
-        highlight_str = "test"
-        is_highlighted = false
+route create_folder_batch/check (async.PollArg, CreateFolderBatchJobStatus, async.PollError)
+    "Returns the status of an asynchronous job for :route:`create_folder_batch`. If success, it
+    returns list of result for each entry."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route delete_batch (DeleteBatchArg, DeleteBatchLaunch, Void)
+    "Delete multiple files/folders at once. This route is asynchronous, which returns a job ID
+    immediately and runs the delete batch asynchronously. Use :route:`delete_batch/check` to
+    check the job status."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route delete_batch/check (async.PollArg, DeleteBatchJobStatus, async.PollError)
+    "Returns the status of an asynchronous job for :route:`delete_batch`. If success, it returns
+    list of result for each entry."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route permanently_delete (DeleteArg, Void, DeleteError)
+    "Permanently delete the file or folder at a given path (see
+    https://www.dropbox.com/en/help/40). If the given file or folder is not yet deleted, this
+    route will first delete it. It is possible for this route to successfully delete, then fail
+    to permanently delete. Note: This endpoint is only available for Dropbox Business apps."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.permanent_delete"
+        select_admin_mode = "team_admin"
+
+route copy (RelocationArg, Metadata, RelocationError) deprecated
+    "Copy a file or folder to a different location in the user's Dropbox.
+    If the source path is a folder all its contents will be copied."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route copy:2 (RelocationArg, RelocationResult, RelocationError)
+    "Copy a file or folder to a different location in the user's Dropbox.
+    If the source path is a folder all its contents will be copied."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route copy_batch (RelocationBatchArg, RelocationBatchLaunch, Void) deprecated
+    "Copy multiple files or folders to different locations at once in the user's Dropbox.
+    This route will return job ID immediately and do the async copy job in background.
+    Please use :route:`copy_batch/check` to check the job status."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route copy_batch:2 (CopyBatchArg, RelocationBatchV2Launch, Void)
+    "Copy multiple files or folders to different locations at once in the user's Dropbox.
+    This route will replace :route:`copy_batch`. The main difference is this route will return
+    status for each entry, while :route:`copy_batch` raises failure if any entry fails. This
+    route will either finish synchronously, or return a job ID and do the async copy job in
+    background. Please use :route:`copy_batch/check:2` to check the job status."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route copy_batch/check (async.PollArg, RelocationBatchJobStatus, async.PollError) deprecated
+    "Returns the status of an asynchronous job for :route:`copy_batch:1`. If success, it returns
+    list of results for each entry."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route copy_batch/check:2 (async.PollArg, RelocationBatchV2JobStatus, async.PollError)
+    "Returns the status of an asynchronous job for :route:`copy_batch:2`. It returns list of
+    results for each entry."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route move_batch (RelocationBatchArg, RelocationBatchLaunch, Void) deprecated
+    "Move multiple files or folders to different locations at once in the user's Dropbox.
+    This route will return job ID immediately and do the async moving job in background.
+    Please use :route:`move_batch/check` to check the job status."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route move_batch:2 (MoveBatchArg, RelocationBatchV2Launch, Void)
+    "Move multiple files or folders to different locations at once in the user's Dropbox.
+    Note that we do not currently support case-only renaming. This route will replace
+    :route:`move_batch`. The main difference is this route will return status for each entry,
+    while :route:`move_batch` raises failure if any entry fails. This route will either finish
+    synchronously, or return a job ID and do the async move job in background. Please use
+    :route:`move_batch/check:2` to check the job status."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route move_batch/check (async.PollArg, RelocationBatchJobStatus, async.PollError) deprecated
+    "Returns the status of an asynchronous job for :route:`move_batch:1`. If success, it returns
+    list of results for each entry."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route move_batch/check:2 (async.PollArg, RelocationBatchV2JobStatus, async.PollError)
+    "Returns the status of an asynchronous job for :route:`move_batch:2`. It returns list of
+    results for each entry."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+
+route create_folder (CreateFolderArg, FolderMetadata, CreateFolderError) deprecated
+    "Create a folder at a given path."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route create_folder:2 (CreateFolderArg, CreateFolderResult, CreateFolderError)
+    "Create a folder at a given path."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route delete (DeleteArg, Metadata, DeleteError) deprecated
+    "Delete the file or folder at a given path. If the path is a folder, all its contents will be
+    deleted too. A successful response indicates that the file or folder was deleted. The returned
+    metadata will be the corresponding FileMetadata or FolderMetadata for the item at time of
+    deletion, and not a DeletedMetadata object."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route delete:2 (DeleteArg, DeleteResult, DeleteError)
+    "Delete the file or folder at a given path. If the path is a folder, all its contents will be
+    deleted too. A successful response indicates that the file or folder was deleted. The returned
+    metadata will be the corresponding FileMetadata or FolderMetadata for the item at time of
+    deletion, and not a DeletedMetadata object."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route move (RelocationArg, Metadata, RelocationError) deprecated
+    "Move a file or folder to a different location in the user's Dropbox. If the source path is
+    a folder all its contents will be moved."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route move:2 (RelocationArg, RelocationResult, RelocationError)
+    "Move a file or folder to a different location in the user's Dropbox. If the source path is
+    a folder all its contents will be moved. Note that we do not currently support case-only
+    renaming."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+
+route get_temporary_link (GetTemporaryLinkArg, GetTemporaryLinkResult, GetTemporaryLinkError)
+    "Get a temporary link to stream content of a file. This link will expire in four hours and
+    afterwards you will get 410 Gone. This URL should not be used to display content directly
+    in the browser. The Content-Type of the link is determined automatically by the file's mime type."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.read"
+
+
+route copy_reference/get (GetCopyReferenceArg, GetCopyReferenceResult, GetCopyReferenceError)
+    "Get a copy reference to a file or folder. This reference string can be used to save that
+    file or folder to another user's Dropbox by passing it to :route:`copy_reference/save`."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+
+route copy_reference/save (SaveCopyReferenceArg, SaveCopyReferenceResult, SaveCopyReferenceError)
+    "Save a copy reference returned by :route:`copy_reference/get` to the user's Dropbox."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+
+
+route download (DownloadArg, FileMetadata, DownloadError)
+    "Download a file from a user's Dropbox."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        host = "content"
+        scope = "files.content.read"
+        select_admin_mode = "whole_team"
+        style = "download"
+
+
+route download_zip (DownloadZipArg, DownloadZipResult, DownloadZipError)
+    "Download a folder from the user's Dropbox, as a zip file. The folder must be less than 20 GB
+    in size and any single file within must be less than 4 GB in size. The resulting zip must have
+    fewer than 10,000 total file and folder entries, including the top level folder. The input
+    cannot be a single file. Note: this endpoint does not support HTTP range requests."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        host = "content"
+        scope = "files.content.read"
+        style = "download"
+
+
+route export (ExportArg, ExportResult, ExportError)
+    "Export a file from a user's Dropbox. This route only supports exporting files that cannot be
+    downloaded directly and whose ExportResult.file_metadata has ExportInfo.export_as populated."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        host = "content"
+        is_preview = true
+        scope = "files.content.read"
+        select_admin_mode = "whole_team"
+        style = "download"
+
+
+route get_temporary_upload_link (GetTemporaryUploadLinkArg, GetTemporaryUploadLinkResult, Void)
+    "Get a one-time use temporary upload link to upload a file to a Dropbox location.  This
+    endpoint acts as a delayed upload(). The returned temporary upload link may be used to make
+    a POST request with the data to be uploaded. The upload will then be perfomed with the
+    CommitInfo previously provided to getTemporaryUploadLink() but evaluated only upon consumption.
+    Hence, errors stemming from invalid CommitInfo with respect to the state of the user's Dropbox
+    will only be communicated at consumption time. Additionally, these errors are surfaced as
+    generic HTTP 409 Conflict responses, potentially hiding issue details. The maximum temporary
+    upload link duration is 4 hours. Upon consumption or expiration, a new link will have to be
+    generated. Multiple links may exist for a specific upload path at any given time.  The POST
+    request on the temporary upload link must have its Content-Type set to
+    \"application/octet-stream\".  Example temporary upload link consumption request:  curl -X POST
+    https://content.dropboxapi.com/apitul/1/bNi2uIYF51cVBND --header
+    \"Content-Type: application/octet-stream\" --data-binary @local_file.txt  A successful temporary
+    upload link consumption request returns the content hash of the uploaded data in JSON format.
+    Example successful temporary upload link consumption response: {\"content-hash\":
+    \"599d71033d700ac892a0e48fa61b125d2f5994\"}  An unsuccessful temporary upload link consumption
+    request returns any of the following status codes:  HTTP 400 Bad Request: Content-Type is not
+    one of application/octet-stream and text/plain or request is invalid. HTTP 409 Conflict: The
+    temporary upload link does not exist or is currently unavailable, the upload failed, or
+    another error happened. HTTP 410 Gone: The temporary upload link is expired or consumed.
+    Example unsuccessful temporary upload link consumption response: Temporary upload link has
+    been recently consumed."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+
+
+route lock_file_batch (LockFileBatchArg, LockFileBatchResult, LockFileError)
+    "Lock the files at the given paths. A locked file will be writable only by the lock holder.
+    A successful response indicates that the file has been locked. Returns a list of the locked
+    file paths and their metadata after this operation."
+
+    attrs
+        auth = "user"
+        scope = "files.content.write"
+
+route unlock_file_batch (UnlockFileBatchArg, LockFileBatchResult, LockFileError)
+    "Unlock the files at the given paths. A locked file can only be unlocked by the lock holder
+    or, if a business account, a team admin. A successful response indicates that the file has
+    been unlocked. Returns a list of the unlocked file paths and their metadata after this
+    operation."
+
+    attrs
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "whole_team"
+
+route get_file_lock_batch (LockFileBatchArg, LockFileBatchResult, LockFileError)
+    "Return the lock metadata for the given list of paths."
+
+    attrs
+        auth = "user"
+        scope = "files.content.read"
+
+
+route get_metadata (GetMetadataArg, Metadata, GetMetadataError)
+    "Returns the metadata for a file or folder.
+    Note: Metadata for the root folder is unsupported."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.metadata.read"
+        select_admin_mode = "whole_team"
+
+route list_folder (ListFolderArg, ListFolderResult, ListFolderError)
+    "Starts returning the contents of a folder. If the result's :field:`ListFolderResult.has_more`
+    field is true, call :route:`list_folder/continue` with the returned ListFolderResult.cursor to
+    retrieve more entries. If you're using ListFolderArg.recursive set to true to keep a local
+    cache of the contents of a Dropbox account, iterate through each entry in order and process
+    them as follows to keep your local state in sync: For each FileMetadata, store the new entry
+    at the given path in your local state. If the required parent folders don't exist yet, create
+    them. If there's already something else at the given path, replace it and remove all its
+    children. For each FolderMetadata, store the new entry at the given path in your local state.
+    If the required parent folders don't exist yet, create them. If there's already something else
+    at the given path, replace it but leave the children as they are. Check the new entry's
+    FolderSharingInfo.read_only and set all its children's read-only statuses to match. For each
+    DeletedMetadata, if your local state has something at the given path, remove it and all its
+    children. If there's nothing at the given path, ignore this entry. Note: auth.RateLimitError
+    may be returned if multiple :route:`list_folder` or :route:`list_folder/continue` calls with same parameters
+    are made simultaneously by same API app for same user. If your app implements retry logic,
+    please hold off the retry until the previous request finishes."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "app, user"
+        scope = "files.metadata.read"
+        select_admin_mode = "whole_team"
+
+route list_folder/continue (ListFolderContinueArg, ListFolderResult, ListFolderContinueError)
+    "Once a cursor has been retrieved from :route:`list_folder`, use this to paginate through all
+    files and retrieve updates to the folder, following the same rules as documented for
+    :route:`list_folder`."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "app, user"
+        scope = "files.metadata.read"
+        select_admin_mode = "whole_team"
+
+route list_folder/get_latest_cursor (ListFolderArg, ListFolderGetLatestCursorResult, ListFolderError)
+    "A way to quickly get a cursor for the folder's state. Unlike :route:`list_folder`,
+    :route:`list_folder/get_latest_cursor` doesn't return any entries. This endpoint is for app which
+    only needs to know about new files and modifications and doesn't need to know about files
+    that already exist in Dropbox."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.metadata.read"
+        select_admin_mode = "whole_team"
+
+route list_folder/longpoll (ListFolderLongpollArg, ListFolderLongpollResult, ListFolderLongpollError)
+    "A longpoll endpoint to wait for changes on an account. In conjunction with :route:`list_folder/continue`,
+    this call gives you a low-latency way to monitor an account for file changes. The connection
+    will block until there are changes available or a timeout occurs. This endpoint is useful
+    mostly for client-side apps."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "noauth"
+        host = "notify"
+        scope = "files.metadata.read"
+        select_admin_mode = "whole_team"
+
+route alpha/get_metadata (AlphaGetMetadataArg, Metadata, AlphaGetMetadataError) deprecated
+    "Returns the metadata for a file or folder. This is an alpha endpoint compatible
+    with the properties API. Note: Metadata for the root folder is unsupported."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        is_preview = true
+        scope = "files.metadata.read"
+
+
+route paper/create (PaperCreateArg, PaperCreateResult, PaperCreateError)
+    "Creates a new Paper doc with the provided content."
+
+    attrs
+        auth = "user"
+        is_preview = true
+        scope = "files.content.write"
+        style = "upload"
+
+route paper/update (PaperUpdateArg, PaperUpdateResult, PaperUpdateError)
+    "Updates an existing Paper doc with the provided content."
+
+    attrs
+        auth = "user"
+        is_preview = true
+        scope = "files.content.write"
+        style = "upload"
+
+
+route get_preview (PreviewArg, FileMetadata, PreviewError)
+    "Get a preview for a file. Currently, PDF previews are generated for files with the following
+    extensions: .ai, .doc, .docm, .docx, .eps, .gdoc, .gslides, .odp, .odt, .pps, .ppsm, .ppsx,
+    .ppt, .pptm, .pptx, .rtf. HTML previews are generated for .csv, .ods, .xls, .xlsm, .gsheet,
+    .xlsx. Other formats will return an unsupported extension error."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        host = "content"
+        scope = "files.content.read"
+        select_admin_mode = "whole_team"
+        style = "download"
+
+route get_thumbnail (ThumbnailArg, FileMetadata, ThumbnailError)
+    "Get a thumbnail for an image. This method currently supports files with the following file
+    extensions: jpg, jpeg, png, tiff, tif, gif, webp, ppm and bmp. Photos that are larger than
+    20MB in size won't be converted to a thumbnail."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        host = "content"
+        scope = "files.content.read"
+        select_admin_mode = "whole_team"
+        style = "download"
+
+route get_thumbnail_batch (GetThumbnailBatchArg, GetThumbnailBatchResult, GetThumbnailBatchError)
+    "Get thumbnails for a list of images. We allow up to 25 thumbnails in a single batch. This
+    method currently supports files with the following file extensions: jpg, jpeg, png, tiff, tif,
+    gif, webp, ppm and bmp. Photos that are larger than 20MB in size won't be converted to a
+    thumbnail."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        host = "content"
+        scope = "files.content.read"
+        select_admin_mode = "whole_team"
+
+route get_thumbnail:2 (ThumbnailV2Arg, PreviewResult, ThumbnailV2Error)
+    "Get a thumbnail for an image. This method currently supports files with the following file
+    extensions: jpg, jpeg, png, tiff, tif, gif, webp, ppm and bmp. Photos that are larger than
+    20MB in size won't be converted to a thumbnail."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "app, user"
+        host = "content"
+        scope = "files.content.read"
+        select_admin_mode = "whole_team"
+        style = "download"
+
+
+route properties/add (file_properties.AddPropertiesArg, Void, file_properties.AddPropertiesError) deprecated
+    "Add property groups to a Dropbox file. See templates/add_for_user or
+    templates/add_for_team to create new templates."
+
+    attrs
+        auth = "user"
+        scope = "files.metadata.write"
+
+route properties/update (file_properties.UpdatePropertiesArg, Void, file_properties.UpdatePropertiesError) deprecated
+    "Add, update or remove properties associated with the supplied file and templates.
+    This endpoint should be used instead of properties/overwrite when property groups
+    are being updated via a \"delta\" instead of overwriting all properties of a file."
+
+    attrs
+        auth = "user"
+        scope = "files.metadata.write"
+
+route properties/overwrite (file_properties.OverwritePropertyGroupArg, Void, file_properties.InvalidPropertyGroupError) deprecated
+    "Overwrite property groups associated with a file. This endpoint should be used
+    instead of properties/update when property groups are being overwritten rather
+    than updated via a \"delta\"."
+
+    attrs
+        auth = "user"
+        scope = "files.metadata.write"
+
+
+route save_url (SaveUrlArg, SaveUrlResult, SaveUrlError)
+    "Save the data from a specified URL into a file in user's Dropbox.
+    Note that the transfer from the URL must complete within 15 minutes, or the
+    operation will time out and the job will fail."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+
+route save_url/check_job_status (async.PollArg, SaveUrlJobStatus, async.PollError)
+    "Check the status of a :route:`save_url` job."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+
+
+route upload (UploadArg, FileMetadata, UploadError)
+    "Create a new file with the contents provided in the request. Do not use this to upload a
+    file larger than 150 MiB. Instead, create an upload session with :route:`upload_session/start`.
+    Calls to this endpoint will count as data transport calls for any Dropbox Business teams
+    with a limit on the number of data transport calls allowed per month. For more information,
+    see the Data transport limit page https://www.dropbox.com/developers/reference/data-transport-limit."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        host = "content"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+        style = "upload"
+
+route upload_session/start (UploadSessionStartArg, UploadSessionStartResult, UploadSessionStartError)
+    "Upload sessions allow you to upload a single file in one or more requests, for example where
+    the size of the file is greater than 150 MiB. This call starts a new upload session with the
+    given data. You can then use :route:`upload_session/append:2` or :route:`upload_session/append_batch` to add
+    more data, then :route:`upload_session/finish` or :route:`upload_session/finish_batch:2` to save all the data to
+    a file in Dropbox. A single request should not upload more than 150 MiB. The maximum size of
+    a file one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248) bytes.
+    An upload session can be used for a maximum of 7 days. Attempting to use a
+    :field:`UploadSessionStartResult.session_id` with :route:`upload_session/append:2` or other upload session
+    routes more than 7 days after its creation will return :field:`UploadSessionLookupError.not_found`.
+    Calls to this endpoint will count as data transport calls for any Dropbox Business teams with a
+    limit on the number of data transport calls allowed per month. For more information, see the
+    Data transport limit page https://www.dropbox.com/developers/reference/data-transport-limit.
+    By default, upload sessions require you to send content of the file in sequential order via
+    consecutive :route:`upload_session/start`, :route:`upload_session/append:2`, and :route:`upload_session/finish` calls
+    (or their batch variants). For better performance, you can optionally set
+    :field:`UploadSessionStartArg.session_type` to :field:`UploadSessionType.concurrent` to start a concurrent
+    upload session. Concurrent upload sessions may upload file data in concurrent
+    :route:`upload_session/append:2` requests, with a few caveats. After all of the requests are complete,
+    finish the session with :route:`upload_session/finish` as normal. You can not send data in a
+    :route:`upload_session/start` or :route:`upload_session/finish` call, only with :route:`upload_session/append:2` or
+    :route:`upload_session/append_batch`. Also, the length of the uploaded data in a call to
+    :route:`upload_session/append:2` or :route:`upload_session/append_batch` must be a multiple of 2^22 (4,194,304)
+    bytes, except for the final append request with :field:`UploadSessionAppendArg.close` or
+    :field:`UploadSessionAppendBatchArgEntry.close` set to true that may contain any remaining data."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        host = "content"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+        style = "upload"
+
+route upload_session/append (UploadSessionCursor, Void, UploadSessionAppendError) deprecated
+    "Append more data to an upload session. A single request should not upload more than 150 MiB.
+    The maximum size of a file one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248) bytes.
+    Calls to this endpoint will count as data transport calls for any Dropbox Business teams with a
+    limit on the number of data transport calls allowed per month. For more information, see the
+    Data transport limit page https://www.dropbox.com/developers/reference/data-transport-limit."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        host = "content"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+        style = "upload"
+
+route upload_session/append:2 (UploadSessionAppendArg, Void, UploadSessionAppendError)
+    "Append more data to an upload session. When the parameter close is set, this call will close
+    the session. A single request should not upload more than 150 MiB. The maximum size of a file
+    one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248) bytes. Calls to this
+    endpoint will count as data transport calls for any Dropbox Business teams with a limit on the
+    number of data transport calls allowed per month. For more information, see the Data transport
+    limit page https://www.dropbox.com/developers/reference/data-transport-limit."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        host = "content"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+        style = "upload"
+
+route upload_session/append_batch (UploadSessionAppendBatchArg, UploadSessionAppendBatchResult, UploadSessionAppendBatchError)
+    "Append more data to multiple upload sessions. Each piece of file content to append to each
+    upload session should be concatenated in the request body, in the order delineated by
+    :field:`UploadSessionAppendBatchArg.entries` and their individual lengths indicated by
+    :field:`UploadSessionAppendBatchArgEntry.length`. A single request should not upload more than 150 MiB.
+    The maximum size of a file one can upload to an upload session is
+    2^41 - 2^22 (2,199,019,061,248) bytes. Calls to this endpoint will count as data transport
+    calls for any Dropbox Business teams with a limit on the number of data transport calls allowed
+    per month. For more information, see the Data transport limit page
+    https://www.dropbox.com/developers/reference/data-transport-limit."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        host = "content"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+        style = "upload"
+
+route upload_session/finish (UploadSessionFinishArg, FileMetadata, UploadSessionFinishError)
+    "Finish an upload session and save the uploaded data to the given file path. A single request
+    should not upload more than 150 MiB. The maximum size of a file one can upload to an upload
+    session is 2^41 - 2^22 (2,199,019,061,248) bytes. Calls to this endpoint will count as data
+    transport calls for any Dropbox Business teams with a limit on the number of data transport
+    calls allowed per month. For more information, see the Data transport limit page
+    https://www.dropbox.com/developers/reference/data-transport-limit."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        host = "content"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+        style = "upload"
+
+route alpha/upload (UploadArg, FileMetadata, UploadError) deprecated
+    "Create a new file with the contents provided in the request. Note that the behavior of this
+    alpha endpoint is unstable and subject to change. Do not use this to upload a file larger
+    than 150 MiB. Instead, create an upload session with :route:`upload_session/start`."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        host = "content"
+        is_preview = true
+        scope = "files.content.write"
+        style = "upload"
+
+
+route upload_session/start_batch (UploadSessionStartBatchArg, UploadSessionStartBatchResult, Void)
+    "Start a batch of upload sessions. See :route:`upload_session/start`. Calls to this endpoint will count
+    as data transport calls for any Dropbox Business teams with a limit on the number of data
+    transport calls allowed per month. For more information, see the Data transport limit page
+    https://www.dropbox.com/developers/reference/data-transport-limit."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+
+route upload_session/finish_batch (UploadSessionFinishBatchArg, UploadSessionFinishBatchLaunch, Void) deprecated
+    "This route helps you commit many files at once into a user's Dropbox. Use :route:`upload_session/start`
+    and :route:`upload_session/append:2` to upload file contents. We recommend uploading many files in
+    parallel to increase throughput. Once the file contents have been uploaded, rather than
+    calling :route:`upload_session/finish`, use this route to finish all your upload sessions in a single
+    request. :field:`UploadSessionStartArg.close` or :field:`UploadSessionAppendArg.close` needs to be true for
+    the last :route:`upload_session/start` or :route:`upload_session/append:2` call. The maximum size of a file
+    one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248) bytes. This route will
+    return a job_id immediately and do the async commit job in background. Use
+    :route:`upload_session/finish_batch/check` to check the job status. For the same account, this route
+    should be executed serially. That means you should not start the next job before current job
+    finishes. We allow up to 1000 entries in a single request. Calls to this endpoint will count
+    as data transport calls for any Dropbox Business teams with a limit on the number of data
+    transport calls allowed per month. For more information, see the Data transport limit page
+    https://www.dropbox.com/developers/reference/data-transport-limit."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route upload_session/finish_batch:2 (UploadSessionFinishBatchArg, UploadSessionFinishBatchResult, Void)
+    "This route helps you commit many files at once into a user's Dropbox. Use :route:`upload_session/start`
+    and :route:`upload_session/append:2` to upload file contents. We recommend uploading many files in
+    parallel to increase throughput. Once the file contents have been uploaded, rather than
+    calling :route:`upload_session/finish`, use this route to finish all your upload sessions in a single
+    request. :field:`UploadSessionStartArg.close` or :field:`UploadSessionAppendArg.close` needs to be true for
+    the last :route:`upload_session/start` or :route:`upload_session/append:2` call of each upload session. The
+    maximum size of a file one can upload to an upload session is 2^41 - 2^22 (2,199,019,061,248)
+    bytes. We allow up to 1000 entries in a single request. Calls to this endpoint will count
+    as data transport calls for any Dropbox Business teams with a limit on the number of data
+    transport calls allowed per month. For more information, see the Data transport limit page
+    https://www.dropbox.com/developers/reference/data-transport-limit."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+route upload_session/finish_batch/check (async.PollArg, UploadSessionFinishBatchJobStatus, async.PollError)
+    "Returns the status of an asynchronous job for :route:`upload_session/finish_batch`. If success, it
+    returns list of result for each entry."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+
+route list_revisions (ListRevisionsArg, ListRevisionsResult, ListRevisionsError)
+    "Returns revisions for files based on a file path or a file id. The file path or file id is
+    identified from the latest file entry at the given file path or id. This end point allows
+    your app to query either by file path or file id by setting the mode parameter appropriately.
+    In the ListRevisionsMode.path (default) mode, all revisions at the same file path as the
+    latest file entry are returned. If revisions with the same file id are desired, then mode
+    must be set to ListRevisionsMode.id. The ListRevisionsMode.id mode is useful to retrieve
+    revisions for a given file across moves or renames."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.metadata.read"
+        select_admin_mode = "whole_team"
+
+route restore (RestoreArg, FileMetadata, RestoreError)
+    "Restore a specific revision of a file to the given path."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.content.write"
+        select_admin_mode = "team_admin"
+
+
+route search (SearchArg, SearchResult, SearchError) deprecated
+    "Searches for files and folders.
+    Note: Recent changes will be reflected in search results within a few seconds
+    and older revisions of existing files may still match your query for up to a few days."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "files.metadata.read"
 

--- a/openid.stone
+++ b/openid.stone
@@ -3,6 +3,17 @@ namespace openid
 import account_id
 import common
 
+route userinfo (UserInfoArgs, UserInfoResult, UserInfoError)
+    "This route is used for refreshing the info that is found in the id_token during the OIDC flow.
+    This route doesn't require any arguments and will use the scopes approved for the given access token."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        is_preview = true
+        scope = "openid"
+
+
 union OpenIdError
     incorrect_openid_scopes
         "Missing openid claims for the associated access token."
@@ -28,15 +39,4 @@ struct UserInfoResult
     sub String = ""
         "An identifier for the user. This is the Dropbox account_id, a string
         value such as dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc."
-
-
-route userinfo (UserInfoArgs, UserInfoResult, UserInfoError)
-    "This route is used for refreshing the info that is found in the id_token during the OIDC flow.
-    This route doesn't require any arguments and will use the scopes approved for the given access token."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        is_preview = true
-        scope = "openid"
 

--- a/paper.stone
+++ b/paper.stone
@@ -7,6 +7,136 @@ import common
 import files
 import sharing
 
+route docs/folder_users/list (ListUsersOnFolderArgs, ListUsersOnFolderResponse, DocLookupError) deprecated
+    "Lists the users who are explicitly invited to the Paper folder in which the Paper doc is contained. For private folders all users (including owner) shared on the folder are listed and for team folders all non-team users shared on the folder are returned. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
+
+route docs/folder_users/list/continue (ListUsersOnFolderContinueArgs, ListUsersOnFolderResponse, ListUsersCursorError) deprecated
+    "Once a cursor has been retrieved from :route:`docs/folder_users/list`, use this to paginate through all users on the Paper folder. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
+
+route docs/sharing_policy/get (RefPaperDoc, SharingPolicy, DocLookupError) deprecated
+    "Gets the default sharing policy for the given Paper doc. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
+
+route docs/sharing_policy/set (PaperDocSharingPolicy, Void, DocLookupError) deprecated
+    "Sets the default sharing policy for the given Paper doc. The default 'team_sharing_policy' can be changed only by teams, omit this field for personal accounts. The 'public_sharing_policy' policy can't be set to the value 'disabled' because this setting can be changed only via the team admin console. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
+
+    attrs
+        auth = "user"
+        scope = "sharing.write"
+
+route docs/archive (RefPaperDoc, Void, DocLookupError) deprecated
+    "Marks the given Paper doc as archived. This action can be performed or undone by anyone with edit permissions to the doc. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. This endpoint will be retired in September 2020. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for more information."
+
+    attrs
+        auth = "user"
+        scope = "files.content.write"
+
+route docs/permanently_delete (RefPaperDoc, Void, DocLookupError) deprecated
+    "Permanently deletes the given Paper doc. This operation is final as the doc cannot be recovered. This action can be performed only by the doc owner. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
+
+    attrs
+        auth = "user"
+        scope = "files.permanent_delete"
+
+route docs/download (PaperDocExport, PaperDocExportResult, DocLookupError) deprecated
+    "Exports and downloads Paper doc either as HTML or markdown. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
+
+    attrs
+        auth = "user"
+        scope = "files.content.read"
+        style = "download"
+
+route docs/get_folder_info (RefPaperDoc, FoldersContainingPaperDoc, DocLookupError) deprecated
+    "Retrieves folder information for the given Paper doc. This includes: - folder sharing policy; permissions for subfolders are set by the top-level folder. - full 'filepath', i.e. the list of folders (both folderId and folderName) from the root folder to the folder directly containing the Paper doc. If the Paper doc is not in any folder (aka unfiled) the response will be empty. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
+
+route docs/users/add (AddPaperDocUser, List(AddPaperDocUserMemberResult), DocLookupError) deprecated
+    "Allows an owner or editor to add users to a Paper doc or change their permissions using their email address or Dropbox account ID. The doc owner's permissions cannot be changed. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
+
+    attrs
+        auth = "user"
+        scope = "sharing.write"
+
+route docs/users/remove (RemovePaperDocUser, Void, DocLookupError) deprecated
+    "Allows an owner or editor to remove users from a Paper doc using their email address or Dropbox account ID. The doc owner cannot be removed. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
+
+    attrs
+        auth = "user"
+        scope = "sharing.write"
+
+route docs/users/list (ListUsersOnPaperDocArgs, ListUsersOnPaperDocResponse, DocLookupError) deprecated
+    "Lists all users who visited the Paper doc or users with explicit access. This call excludes users who have been removed. The list is sorted by the date of the visit or the share date. The list will include both users, the explicitly shared ones as well as those who came in using the Paper url link. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
+
+route docs/users/list/continue (ListUsersOnPaperDocContinueArgs, ListUsersOnPaperDocResponse, ListUsersCursorError) deprecated
+    "Once a cursor has been retrieved from :route:`docs/users/list`, use this to paginate through all users on the Paper doc. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
+
+route docs/list (ListPaperDocsArgs, ListPaperDocsResponse, Void) deprecated
+    "Return the list of all Paper docs according to the argument specifications. To iterate over through the full pagination, pass the cursor to :route:`docs/list/continue`. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
+
+    attrs
+        auth = "user"
+        scope = "files.metadata.read"
+
+route docs/list/continue (ListPaperDocsContinueArgs, ListPaperDocsResponse, ListDocsCursorError) deprecated
+    "Once a cursor has been retrieved from :route:`docs/list`, use this to paginate through all Paper doc. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
+
+    attrs
+        auth = "user"
+        scope = "files.metadata.read"
+
+route docs/create (PaperDocCreateArgs, PaperDocCreateUpdateResult, PaperDocCreateError) deprecated
+    "Creates a new Paper doc with the provided content. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. This endpoint will be retired in September 2020. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for more information."
+
+    attrs
+        auth = "user"
+        scope = "files.content.write"
+        style = "upload"
+
+route docs/update (PaperDocUpdateArgs, PaperDocCreateUpdateResult, PaperDocUpdateError) deprecated
+    "Updates an existing Paper doc with the provided content. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. This endpoint will be retired in September 2020. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for more information."
+
+    attrs
+        auth = "user"
+        scope = "files.content.write"
+        style = "upload"
+
+route folders/create (PaperFolderCreateArg, PaperFolderCreateResult, PaperFolderCreateError) deprecated
+    "Create a new Paper folder with the provided info. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
+
+    attrs
+        auth = "user"
+        scope = "files.content.write"
+
+route docs/get_metadata (GetDocMetadataArg, PaperDocGetMetadataResult, DocLookupError)
+    "Returns metadata for a Paper doc or Cloud Doc."
+
+    attrs
+        auth = "user"
+        scope = "files.metadata.read"
+
+
 alias PaperDocId = String
 
 struct RefPaperDoc
@@ -403,7 +533,7 @@ struct PaperDocCreateArgs
 
     example default
         import_format = markdown
-    
+
     example createDocInFolder
         import_format = html
         parent_folder_id = "e.gGYT6HSafpMej9bUv306GarglI7GGeAM3yvfZvXHO9u4mV"
@@ -452,7 +582,7 @@ struct PaperDocUpdateArgs extends RefPaperDoc
         import_format = html
         doc_id = "uaSvRuxvnkFa12PTkBv5q"
         revision = 12345
-    
+
     example prepend_example
         doc_update_policy = prepend
         import_format = plain_text
@@ -483,11 +613,11 @@ struct PaperFolderCreateArg
 
     example default
         name = "my new folder"
-    
+
     example createTopLevelTeamFolder
         name = "my new folder"
         is_team_folder = true
-    
+
     example createSubFolder
         name = "my new folder"
         parent_folder_id = "e.gGYT6HSafpMej9bUv306GarglI7GGeAM3yvfZvXHO9u4mV"
@@ -547,134 +677,4 @@ struct PaperDocGetMetadataResult
         revision = 56556
         last_updated_date = "2017-01-02T00:00:00Z"
         last_editor = "stephen@example.com"
-
-
-route docs/folder_users/list (ListUsersOnFolderArgs, ListUsersOnFolderResponse, DocLookupError) deprecated
-    "Lists the users who are explicitly invited to the Paper folder in which the Paper doc is contained. For private folders all users (including owner) shared on the folder are listed and for team folders all non-team users shared on the folder are returned. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-
-route docs/folder_users/list/continue (ListUsersOnFolderContinueArgs, ListUsersOnFolderResponse, ListUsersCursorError) deprecated
-    "Once a cursor has been retrieved from :route:`docs/folder_users/list`, use this to paginate through all users on the Paper folder. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-
-route docs/sharing_policy/get (RefPaperDoc, SharingPolicy, DocLookupError) deprecated
-    "Gets the default sharing policy for the given Paper doc. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-
-route docs/sharing_policy/set (PaperDocSharingPolicy, Void, DocLookupError) deprecated
-    "Sets the default sharing policy for the given Paper doc. The default 'team_sharing_policy' can be changed only by teams, omit this field for personal accounts. The 'public_sharing_policy' policy can't be set to the value 'disabled' because this setting can be changed only via the team admin console. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
-
-    attrs
-        auth = "user"
-        scope = "sharing.write"
-
-route docs/archive (RefPaperDoc, Void, DocLookupError) deprecated
-    "Marks the given Paper doc as archived. This action can be performed or undone by anyone with edit permissions to the doc. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. This endpoint will be retired in September 2020. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for more information."
-
-    attrs
-        auth = "user"
-        scope = "files.content.write"
-
-route docs/permanently_delete (RefPaperDoc, Void, DocLookupError) deprecated
-    "Permanently deletes the given Paper doc. This operation is final as the doc cannot be recovered. This action can be performed only by the doc owner. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
-
-    attrs
-        auth = "user"
-        scope = "files.permanent_delete"
-
-route docs/download (PaperDocExport, PaperDocExportResult, DocLookupError) deprecated
-    "Exports and downloads Paper doc either as HTML or markdown. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
-
-    attrs
-        auth = "user"
-        scope = "files.content.read"
-        style = "download"
-
-route docs/get_folder_info (RefPaperDoc, FoldersContainingPaperDoc, DocLookupError) deprecated
-    "Retrieves folder information for the given Paper doc. This includes: - folder sharing policy; permissions for subfolders are set by the top-level folder. - full 'filepath', i.e. the list of folders (both folderId and folderName) from the root folder to the folder directly containing the Paper doc. If the Paper doc is not in any folder (aka unfiled) the response will be empty. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-
-route docs/users/add (AddPaperDocUser, List(AddPaperDocUserMemberResult), DocLookupError) deprecated
-    "Allows an owner or editor to add users to a Paper doc or change their permissions using their email address or Dropbox account ID. The doc owner's permissions cannot be changed. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
-
-    attrs
-        auth = "user"
-        scope = "sharing.write"
-
-route docs/users/remove (RemovePaperDocUser, Void, DocLookupError) deprecated
-    "Allows an owner or editor to remove users from a Paper doc using their email address or Dropbox account ID. The doc owner cannot be removed. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
-
-    attrs
-        auth = "user"
-        scope = "sharing.write"
-
-route docs/users/list (ListUsersOnPaperDocArgs, ListUsersOnPaperDocResponse, DocLookupError) deprecated
-    "Lists all users who visited the Paper doc or users with explicit access. This call excludes users who have been removed. The list is sorted by the date of the visit or the share date. The list will include both users, the explicitly shared ones as well as those who came in using the Paper url link. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-
-route docs/users/list/continue (ListUsersOnPaperDocContinueArgs, ListUsersOnPaperDocResponse, ListUsersCursorError) deprecated
-    "Once a cursor has been retrieved from :route:`docs/users/list`, use this to paginate through all users on the Paper doc. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-
-route docs/list (ListPaperDocsArgs, ListPaperDocsResponse, Void) deprecated
-    "Return the list of all Paper docs according to the argument specifications. To iterate over through the full pagination, pass the cursor to :route:`docs/list/continue`. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
-
-    attrs
-        auth = "user"
-        scope = "files.metadata.read"
-
-route docs/list/continue (ListPaperDocsContinueArgs, ListPaperDocsResponse, ListDocsCursorError) deprecated
-    "Once a cursor has been retrieved from :route:`docs/list`, use this to paginate through all Paper doc. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
-
-    attrs
-        auth = "user"
-        scope = "files.metadata.read"
-
-route docs/create (PaperDocCreateArgs, PaperDocCreateUpdateResult, PaperDocCreateError) deprecated
-    "Creates a new Paper doc with the provided content. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. This endpoint will be retired in September 2020. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for more information."
-
-    attrs
-        auth = "user"
-        scope = "files.content.write"
-        style = "upload"
-
-route docs/update (PaperDocUpdateArgs, PaperDocCreateUpdateResult, PaperDocUpdateError) deprecated
-    "Updates an existing Paper doc with the provided content. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. This endpoint will be retired in September 2020. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for more information."
-
-    attrs
-        auth = "user"
-        scope = "files.content.write"
-        style = "upload"
-
-route folders/create (PaperFolderCreateArg, PaperFolderCreateResult, PaperFolderCreateError) deprecated
-    "Create a new Paper folder with the provided info. Note that this endpoint will continue to work for content created by users on the older version of Paper. To check which version of Paper a user is on, use /users/features/get_values. If the paper_as_files feature is enabled, then the user is running the new version of Paper. Refer to the :link:`Paper Migration Guide https://www.dropbox.com/lp/developers/reference/paper-migration-guide` for migration information."
-
-    attrs
-        auth = "user"
-        scope = "files.content.write"
-
-route docs/get_metadata (GetDocMetadataArg, PaperDocGetMetadataResult, DocLookupError)
-    "Returns metadata for a Paper doc or Cloud Doc."
-
-    attrs
-        auth = "user"
-        scope = "files.metadata.read"
 

--- a/riviera.stone
+++ b/riviera.stone
@@ -125,3 +125,73 @@ route get_transcript_async/check (async.PollArg, GetTranscriptAsyncCheckResult, 
         is_preview = true
         scope = "files.content.read"
 
+
+struct GetMarkdownArgs
+    "Arguments for the asynchronous `get_markdown_async` route.
+    Exactly one of `file_id`, `path`, or `url` must be supplied via
+    `file_id_or_url` to identify the document to convert to markdown."
+    file_id_or_url FileIdOrUrl?
+        "Identifier of the document to convert. Callers must set exactly one of
+        the oneof variants:
+        - file_id: a Dropbox-issued file id (format: \"id:<id>\") for a file the
+        authenticated user has access to.
+        - path: an absolute Dropbox path, e.g. \"/folder/report.docx\".
+        - url: either a Dropbox shared link (www.dropbox.com) or an external
+        HTTPS URL pointing to a supported document file.
+        - Dropbox shared links are resolved internally using the caller's
+        authenticated identity and the link's visibility / download
+        settings. They therefore require an authenticated user context
+        (anonymous `url` requests against Dropbox links are rejected with
+        an `ACCESS_ERROR`). Links protected by a password are rejected
+        with `shared_link_password_protected`; links with downloads
+        disabled are rejected with `link_download_disabled_error`.
+        - External URLs are fetched over HTTPS through the backend's
+        egress proxy and must point at a supported document file
+        extension.
+        The referenced file must be a document in a supported format;
+        requests against unsupported formats return `unsupported_format_error`."
+    enable_ocr Boolean = false
+        "Enable OCR for PDF documents. Processing is slower when enabled."
+    embed_images Boolean = false
+        "When true, embed images as base64 data URIs in the markdown output.
+        This can significantly increase output size."
+
+struct GetMarkdownResult
+    markdown String = ""
+        "The converted markdown content"
+
+union MarkdownConversionApiV2Error
+    server_error String = ""
+    user_error String = ""
+    unsupported_format_error
+    link_download_disabled_error
+    shared_link_password_protected
+    limit_exceeded_error
+    conversion_failure_error
+
+struct GetMarkdownAsyncError
+    error_code ErrorCode = unknown_error
+    error_details MarkdownConversionApiV2Error?
+
+union GetMarkdownAsyncCheckResult
+    "Result type for EventBus async check"
+    in_progress
+    complete GetMarkdownResult
+    failed GetMarkdownAsyncError
+
+route get_markdown_async (GetMarkdownArgs, async.LaunchResultBase, Void)
+    "Asynchronous document-to-markdown conversion for supported file formats."
+
+    attrs
+        auth = "app, user"
+        is_preview = true
+        scope = "files.content.read"
+
+route get_markdown_async/check (async.PollArg, GetMarkdownAsyncCheckResult, async.PollError)
+    "Returns the status or result of specified get_markdown_async task."
+
+    attrs
+        auth = "app, user"
+        is_preview = true
+        scope = "files.content.read"
+

--- a/secondary_emails.stone
+++ b/secondary_emails.stone
@@ -11,11 +11,11 @@ struct SecondaryEmail
     example default
         email = "apple@orange.com"
         is_verified = true
-    
+
     example second_sec_email
         email = "banana@honeydew.com"
         is_verified = true
-    
+
     example third_sec_email
         email = "grape@strawberry.com"
         is_verified = false

--- a/sharing.stone
+++ b/sharing.stone
@@ -12,6 +12,1791 @@ import team_policies
 import users
 import users_common
 
+route get_file_metadata (GetFileMetadataArg, SharedFileMetadata, GetFileMetadataError)
+    "Returns shared file metadata."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
+        select_admin_mode = "team_admin"
+
+
+route list_file_members (ListFileMembersArg, SharedFileMembers, ListFileMembersError)
+    "Use to obtain the members who have been invited to a file, both inherited
+    and uninherited members."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
+        select_admin_mode = "whole_team"
+
+
+route list_shared_links (ListSharedLinksArg, ListSharedLinksResult, ListSharedLinksError)
+    "List shared links of this user.
+    If no path is given, returns a list of all shared links for the current user. For members of
+    business teams using team space and member folders, returns all shared links in the team
+    member's home folder unless the team space ID is specified in the request header.
+    If a non-empty path is given, returns a list of all shared links that allow access to the
+    given path - direct links to the given path and links to parent folders of the given path.
+    Links to parent folders can be suppressed by setting direct_only to true."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "sharing.read"
+        select_admin_mode = "whole_team"
+
+
+union LinkExpiry
+    remove_expiry
+        "Remove the currently set expiry for the link."
+    set_expiry common.DropboxTimestamp
+        "Set a new expiry or change an existing expiry."
+
+union LinkPassword
+    remove_password
+        "Remove the currently set password for the link."
+    set_password String
+        "Set a new password or change an existing password."
+
+union LinkAudience
+    public
+        "Link is accessible by anyone."
+    team
+        "Link is accessible only by team members."
+    no_one
+        "The link can be used by no one. The link merely points the user to the content, and does
+        not grant additional rights to the user. Members of the content who use this link can only
+        access the content with their pre-existing access rights."
+    password
+        @common.Deprecated
+        "Use `require_password` instead. A link-specific password is required to access the
+        link. Login is not required."
+    members
+        @common.Deprecated
+        "Link is accessible only by members of the content."
+
+union LinkAction
+    "Actions that can be performed on a link."
+    change_access_level
+        "Change the access level of the link."
+    change_audience
+        "Change the audience of the link."
+    remove_expiry
+        "Remove the expiry date of the link."
+    remove_password
+        "Remove the password of the link."
+    set_expiry
+        "Create or modify the expiry date of the link."
+    set_password
+        "Create or modify the password of the link."
+
+struct LinkSettings
+    "Settings that apply to a link."
+    access_level AccessLevel?
+        "The access level on the link for this file. Currently,
+        it only accepts 'viewer' and 'viewer_no_comment'."
+    audience LinkAudience?
+        "The type of audience on the link for this file."
+    expiry LinkExpiry?
+        "An expiry timestamp to set on a link."
+    password LinkPassword?
+        "The password for the link."
+
+struct LinkPermission
+    "Permissions for actions that can be performed on a link."
+    action LinkAction
+    allow Boolean
+    reason PermissionDeniedReason?
+
+    example default
+        action = change_audience
+        allow = true
+
+struct SharedContentLinkMetadataBase
+    access_level AccessLevel?
+        "The access level on the link for this file."
+    audience_options List(LinkAudience)
+        "The audience options that are available for the content. Some audience options may be
+        unavailable. For example, team_only may be unavailable if the content is not owned by a
+        user on a team. The 'default' audience option is always available if the user can modify
+        link settings."
+    audience_restricting_shared_folder AudienceRestrictingSharedFolder?
+        "The shared folder that prevents the link audience for this link from being more
+        restrictive."
+    current_audience LinkAudience
+        "The current audience of the link."
+    expiry common.DropboxTimestamp?
+        "Whether the link has an expiry set on it. A link with an expiry will have its
+        audience changed to members when the expiry is reached."
+    link_permissions List(LinkPermission)
+        "A list of permissions for actions you can perform on the link."
+    password_protected Boolean
+        "Whether the link is protected by a password."
+
+struct SharedContentLinkMetadata extends SharedContentLinkMetadataBase
+    "Metadata of a shared link for a file or folder."
+    audience_exceptions AudienceExceptions?
+        "The content inside this folder with link audience different than this folder's. This is
+        only returned when an endpoint that returns metadata for a single shared folder is called,
+        e.g. /get_folder_metadata."
+    url String
+        "The URL of the link."
+
+    example default
+        audience_options = [public, team, members]
+        current_audience = public
+        link_permissions = [default]
+        password_protected = false
+        url = ""
+
+struct ExpectedSharedContentLinkMetadata extends SharedContentLinkMetadataBase
+    "The expected metadata of a shared link for a file or folder when a link is first created for
+    the content. Absent if the link already exists."
+
+    example default
+        audience_options = [public, team, members]
+        current_audience = public
+        link_permissions = [default]
+        password_protected = false
+
+struct AudienceRestrictingSharedFolder
+    "Information about the shared folder that prevents the link audience for this link from being
+    more restrictive."
+    shared_folder_id common.SharedFolderId
+        "The ID of the shared folder."
+    name String
+        "The name of the shared folder."
+    audience LinkAudience
+        "The link audience of the shared folder."
+
+struct AudienceExceptions
+    "The total count and truncated list of information of content inside this folder that has a
+    different audience than the link on this folder. This is only returned for folders."
+    count UInt32
+    exceptions List(AudienceExceptionContentInfo)
+        "A truncated list of some of the content that is an exception. The length of this list could
+        be smaller than the count since it is only a sample but will not be empty as long as
+        count is not 0."
+
+    example default
+        count = 0
+        exceptions = []
+
+struct AudienceExceptionContentInfo
+    "Information about the content that has a link audience different than that of this folder."
+    name String
+        "The name of the content, which is either a file or a folder."
+
+    example default
+        name = "sample file name"
+
+
+route get_shared_link_file (GetSharedLinkFileArg, SharedLinkMetadata, GetSharedLinkFileError)
+    "Download the shared link's file from a user's Dropbox.
+    This is a download-style endpoint that returns the file content."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "app, user"
+        host = "content"
+        scope = "sharing.read"
+        style = "download"
+
+
+route create_shared_link_with_settings (CreateSharedLinkWithSettingsArg, SharedLinkMetadata, CreateSharedLinkWithSettingsError)
+    "Create a shared link with custom settings.
+    If no settings are given then the default visibility is RequestedVisibility.public
+    (The resolved visibility, though, may depend on other aspects such as team and shared folder
+    settings)."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "sharing.write"
+        select_admin_mode = "team_admin"
+
+route get_shared_link_metadata (GetSharedLinkMetadataArg, SharedLinkMetadata, SharedLinkMetadataError)
+    "Get the shared link's metadata."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "app, user"
+        scope = "sharing.read"
+
+route modify_shared_link_settings (ModifySharedLinkSettingsArgs, SharedLinkMetadata, ModifySharedLinkSettingsError)
+    "Modify the shared link's settings.
+    If the requested visibility conflict with the shared links policy of the team or the
+    shared folder (in case the linked file is part of a shared folder) then the
+    LinkPermissions.resolved_visibility of the returned SharedLinkMetadata will
+    reflect the actual visibility of the shared link and the
+    LinkPermissions.requested_visibility will reflect the requested visibility."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "sharing.write"
+
+
+route create_shared_link (CreateSharedLinkArg, PathLinkMetadata, CreateSharedLinkError) deprecated
+    "Create a shared link.
+    If a shared link already exists for the given path, that link is returned.
+    Previously, it was technically possible to break a shared link by moving or
+    renaming the corresponding file or folder. In the future, this will no
+    longer be the case, so your app shouldn't rely on this behavior. Instead, if
+    your app needs to revoke a shared link, use revoke_shared_link.
+    DEPRECATED: Use create_shared_link_with_settings instead."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "sharing.write"
+        select_admin_mode = "team_admin"
+
+route get_shared_links (GetSharedLinksArg, GetSharedLinksResult, GetSharedLinksError) deprecated
+    "Returns a list of :type:`LinkMetadata` objects for this user, including collection links.
+    If no path is given, returns a list of all shared links for the current user,
+    including collection links, up to a maximum of 1000 links.
+    If a non-empty path is given, returns a list of all shared links that allow access
+    to the given path. Collection links are never returned in this case.
+    DEPRECATED: Use list_shared_links instead."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "sharing.read"
+
+route revoke_shared_link (RevokeSharedLinkArg, Void, RevokeSharedLinkError)
+    "Revoke a shared link.
+    Note that even after revoking a shared link to a file, the file may be accessible if there are
+    shared links leading to any of the file parent folders. To list all shared links that enable
+    access to a specific file, you can use the list_shared_links with the file as the
+    ListSharedLinksArg.path argument."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "sharing.write"
+        select_admin_mode = "team_admin"
+
+
+alias GetSharedLinkFileArg = GetSharedLinkMetadataArg
+
+alias Id = files.Id
+
+alias Path = files.Path
+
+alias ReadPath = files.ReadPath
+
+alias Rev = files.Rev
+
+alias TeamInfo = users.Team
+
+union AlphaResolvedVisibility extends ResolvedVisibility
+    "check documentation for ResolvedVisibility."
+
+union CreateSharedLinkError
+    path files.LookupError
+
+union_closed CreateSharedLinkWithSettingsError
+    path files.LookupError
+    email_not_verified
+        "This user's email address is not verified. This functionality is only
+        available on accounts with a verified email address. Users can verify
+        their email address :link:`here https://www.dropbox.com/help/317`."
+    shared_link_already_exists SharedLinkAlreadyExistsMetadata?
+        "The shared link already exists. You can call :route:`list_shared_links` to get the
+        existing link, or use the provided metadata if it is returned.
+        Existing link metadata will not be returned if custom settings were specified in the request that could make the existing link incompatible with the requested settings."
+    settings_error SharedLinkSettingsError
+        "There is an error with the given settings."
+    access_denied
+        "The user is not allowed to create a shared link to the specified file. For
+        example, this can occur if the file is restricted or if the user's links are
+        :link:`banned https://help.dropbox.com/files-folders/share/banned-links`."
+    banned_member
+        "The current user has been :link:`banned https://help.dropbox.com/files-folders/share/banned-links` for abuse reasons."
+    too_many_shared_folders
+        "Your Dropbox folder will have too many shared folders after the operation.
+        https://help.dropbox.com/share/shared-folder-faq#Is-there-a-limit-to-the-number-of-shared-folders-I-can-create"
+
+union GetSharedLinkFileError extends SharedLinkError
+    shared_link_is_directory
+        "Directories cannot be retrieved by this endpoint."
+
+union GetSharedLinksError
+    path files.MalformedPathError
+
+union LinkAccessLevel
+    viewer
+        "Users who use the link can view and comment on the content."
+    editor
+        "Users who use the link can edit, view and comment on the content."
+
+union LinkAudienceDisallowedReason extends VisibilityPolicyDisallowedReason
+    "check documentation for VisibilityPolicyDisallowedReason."
+
+union ListSharedLinksError
+    path files.LookupError
+    reset
+        "Indicates that the cursor has been invalidated. Call
+        :route:`list_shared_links` to obtain a new cursor."
+
+union ModifySharedLinkSettingsError extends SharedLinkError
+    settings_error SharedLinkSettingsError
+        "There is an error with the given settings."
+    email_not_verified
+        "This user's email address is not verified. This functionality is only
+        available on accounts with a verified email address. Users can verify
+        their email address :link:`here https://www.dropbox.com/help/317`."
+
+union_closed PendingUploadMode
+    "Flag to indicate pending upload default (for linking to not-yet-existing paths)."
+    file
+        "Assume pending uploads are files."
+    folder
+        "Assume pending uploads are folders."
+
+union RequestedLinkAccessLevel
+    viewer
+        "Users who use the link can view and comment on the content."
+    editor
+        "Users who use the link can edit, view and comment on the content.
+        Note not all file types support edit links yet."
+    max
+        "Request for the maximum access level you can set the link to."
+    default
+        "Request for the default access level the user has set."
+
+union_closed RequestedVisibility
+    "The access permission that can be requested by the caller for the shared link.
+    Note that the final resolved visibility of the shared link takes into account other aspects,
+    such as team and shared folder settings.
+    Check the :type:`ResolvedVisibility` for more info on the possible resolved visibility values
+    of shared links."
+    public
+        "Anyone who has received the link can access it. No login required."
+    team_only
+        "Only members of the same team can
+        access the link. Login is required."
+    password
+        "A link-specific password is required to access the
+        link. Login is not required."
+
+union ResolvedVisibility extends RequestedVisibility
+    "The actual access permissions values of shared links after taking into account user
+    preferences and the team and shared folder settings.
+    Check the :type:`RequestedVisibility` for more info on the possible visibility values
+    that can be set by the shared link's owner."
+    team_and_password
+        "Only members of the same team who
+        have the link-specific password can access the link. Login is required."
+    shared_folder_only
+        "Only members of the shared folder containing the linked file
+        can access the link. Login is required."
+    no_one
+        "The link merely points the user to the content, and does not grant any additional rights.
+        Existing members of the content who use this link can only access the content with their
+        pre-existing access rights. Either on the file directly, or inherited from a parent folder."
+    only_you
+        "Only the current user can view this link."
+
+union RevokeSharedLinkError extends SharedLinkError
+    shared_link_malformed
+        "Shared link is malformed."
+
+union SharedLinkAccessFailureReason
+    login_required
+        "User is not logged in."
+    email_verify_required
+        "This user's email address is not verified. This functionality is only
+        available on accounts with a verified email address. Users can verify
+        their email address :link:`here https://www.dropbox.com/help/317`."
+    password_required
+        "The link is password protected."
+    team_only
+        "Access is allowed for team members only."
+    owner_only
+        "Access is allowed for the shared link's owner only."
+
+union SharedLinkAlreadyExistsMetadata
+    metadata SharedLinkMetadata
+        "Metadata of the shared link that already exists."
+
+union SharedLinkError
+    shared_link_not_found
+        "The shared link wasn't found."
+    shared_link_access_denied
+        "The caller is not allowed to access this shared link."
+    unsupported_link_type
+        "This type of link is not supported; use :route:`files.export` instead."
+    unsupported_parameter_field
+        "Private shared links do not support `path` or `link_password` parameter fields."
+
+union SharedLinkMetadataError extends SharedLinkError
+    "The potential errors for a call to get_shared_link_metadata."
+
+union_closed SharedLinkSettingsError
+    invalid_settings
+        "The given settings are invalid
+        (for example, all attributes of the :type:`SharedLinkSettings` are empty,
+        the requested visibility is :field:`RequestedVisibility.password` but the
+        :field:`SharedLinkSettings.link_password` is missing, :field:`SharedLinkSettings.expires`
+        is set to the past, etc.)."
+    not_authorized
+        "User is not allowed to modify the settings of this link. Note that basic
+        users can only set :field:`RequestedVisibility.public`
+        as the :field:`SharedLinkSettings.requested_visibility` and cannot
+        set :field:`SharedLinkSettings.expires`."
+
+union Visibility
+    "Who can access a shared link.
+    The most open visibility is :field:`public`.
+    The default depends on many aspects, such as team and user
+    preferences and shared folder settings."
+    public
+        "Anyone who has received the link can access it. No login required."
+    team_only
+        "Only members of the same team can
+        access the link. Login is required."
+    password
+        "A link-specific password is required to access the
+        link. Login is not required."
+    team_and_password
+        "Only members of the same team who
+        have the link-specific password can access the link."
+    shared_folder_only
+        "Only members of the shared folder containing the linked file
+        can access the link. Login is required."
+
+union VisibilityPolicyDisallowedReason
+    delete_and_recreate
+        "The user needs to delete and recreate the link to change the visibility policy."
+    restricted_by_shared_folder
+        "The parent shared folder restricts sharing of links outside the shared folder. To change
+        the visibility policy, remove the restriction from the parent shared folder."
+    restricted_by_team
+        "The team policy prevents links being shared outside the team."
+    user_not_on_team
+        "The user needs to be on a team to set this policy."
+    user_account_type
+        "The user is a basic user or is on a limited team."
+    permission_denied
+        "The user does not have permission."
+
+union ChangeLinkExpirationPolicy
+    "Enumerates acceptable values for team's ChangeLinkExpirationPolicy setting."
+    allowed
+    not_allowed
+
+struct LinkMetadata
+    "Metadata for a shared link. This can be either a
+    :type:`PathLinkMetadata` or :type:`CollectionLinkMetadata`."
+    union
+        path PathLinkMetadata
+        collection CollectionLinkMetadata
+    url String
+        "URL of the shared link."
+    visibility Visibility
+        "Who can access the link."
+    expires common.DropboxTimestamp?
+        "Expiration time, if set. By default the link won't expire."
+
+    example default
+        path = default
+
+struct SharedLinkMetadata
+    "The metadata of a shared link."
+    union
+        file FileLinkMetadata
+        folder FolderLinkMetadata
+    url String
+        "URL of the shared link."
+    id Id?
+        "A unique identifier for the linked file."
+    name String
+        "The linked file name (including extension).
+        This never contains a slash."
+    expires common.DropboxTimestamp?
+        "Expiration time, if set. By default the link won't expire."
+    path_lower String?
+        "The lowercased full path in the user's Dropbox. This always starts with a slash.
+        This field will only be present only if the linked file is in the authenticated user's
+        dropbox and the user is the owner of the link."
+    link_permissions LinkPermissions
+        "The link's access permissions."
+    team_member_info TeamMemberInfo?
+        "The team membership information of the link's owner.  This field will only be present
+        if the link's owner is a team member."
+    content_owner_team_info TeamInfo?
+        "The team information of the content's owner. This field will only be present if
+        the content's owner is a team member and the content's owner team is different from the
+        link's owner team."
+
+    example default
+        file = default
+
+    example folder_link_metadata
+        folder = default
+
+struct CollectionLinkMetadata extends LinkMetadata
+    "Metadata for a collection-based shared link."
+
+    example default
+        url = "https://www.dropbox.com/sh/s6fvw6ol7rmqo1x/AAAgWRSbjmYDvPpDB30Sykjfa?dl=0"
+        expires = null
+        visibility = public
+
+struct CreateSharedLinkArg
+    path String
+        "The path to share."
+    short_url Boolean = false
+        @common.Deprecated
+    pending_upload PendingUploadMode?
+        "If it's okay to share a path that does not yet exist, set this to
+        either :field:`PendingUploadMode.file` or :field:`PendingUploadMode.folder`
+        to indicate whether to assume it's a file or folder."
+
+    example default
+        path = "/Homework/Math/Prime_Numbers.txt"
+
+struct CreateSharedLinkWithSettingsArg
+    path ReadPath
+        "The path to be shared by the shared link."
+    settings SharedLinkSettings?
+        "The requested settings for the newly created shared link."
+
+    example default
+        path = "/Prime_Numbers.txt"
+        settings = default
+
+struct FileLinkMetadata extends SharedLinkMetadata
+    "The metadata of a file shared link."
+    client_modified common.DropboxTimestamp
+        "The modification time set by the desktop client
+        when the file was added to Dropbox. Since this time is not verified
+        (the Dropbox server stores whatever the desktop client sends up), this
+        should only be used for display purposes (such as sorting) and not,
+        for example, to determine if a file has changed or not."
+    server_modified common.DropboxTimestamp
+        "The last time the file was modified on Dropbox."
+    rev Rev
+        "A unique identifier for the current revision of a file. This field is
+        the same rev as elsewhere in the API and can be used to detect changes
+        and avoid conflicts."
+    size UInt64
+        "The file size in bytes."
+
+    example default
+        url = "https://www.dropbox.com/s/2sn712vy1ovegw8/Prime_Numbers.txt?dl=0"
+        id = "id:a4ayc_80_OEAAAAAAAAAXw"
+        name = "Prime_Numbers.txt"
+        path_lower = "/homework/math/prime_numbers.txt"
+        link_permissions = default
+        team_member_info = default
+        client_modified = "2015-05-12T15:50:38Z"
+        server_modified = "2015-05-12T15:50:38Z"
+        rev = "a1c10ce0dd78"
+        size = 7212
+
+struct FolderLinkMetadata extends SharedLinkMetadata
+    "The metadata of a folder shared link."
+
+    example default
+        url = "https://www.dropbox.com/sh/s6fvw6ol7rmqo1x/AAAgWRSbjmYDvPpDB30Sykjfa?dl=0"
+        id = "id:a4ayc_80_OEAAAAAAAAAXw"
+        name = "Math"
+        path_lower = "/homework/math"
+        team_member_info = default
+        link_permissions = default
+
+struct GetSharedLinkMetadataArg
+    url String
+        "URL of the shared link."
+    path Path?
+        "If the shared link is to a folder, this parameter can be used to retrieve the metadata for
+        a specific file or sub-folder in this folder. A relative path should be used."
+    link_password String?
+        "If the shared link has a password, this parameter can be used."
+
+    example default
+        url = "https://www.dropbox.com/s/2sn712vy1ovegw8/Prime_Numbers.txt?dl=0"
+        path = "/Prime_Numbers.txt"
+
+struct GetSharedLinksArg
+    path String?
+        "See :route:`get_shared_links` description."
+
+    example default
+        path = ""
+
+    example math_homework_links
+        path = "/Homework/Math"
+
+struct GetSharedLinksResult
+    links List(LinkMetadata)
+        "Shared links applicable to the path argument."
+
+    example default
+        links = [default]
+
+struct LinkAudienceOption
+    audience LinkAudience
+        "Specifies who can access the link."
+    allowed Boolean
+        "Whether the user calling this API can select this audience option."
+    disallowed_reason LinkAudienceDisallowedReason?
+        "If :field:`allowed` is :val:`false`, this will provide the reason that the user is not
+        permitted to set the visibility to this policy."
+
+    example public
+        audience = public
+        allowed = true
+
+    example team
+        audience = team
+        allowed = false
+
+    example no_one
+        audience = no_one
+        allowed = true
+
+struct LinkPermissions
+    resolved_visibility ResolvedVisibility?
+        "The current visibility of the link after considering the shared links policies of the
+        the team (in case the link's owner is part of a team) and the shared folder (in case the
+        linked file is part of a shared folder). This field is shown only if the caller has access
+        to this info (the link's owner always has access to this data). For some links, an
+        effective_audience value is returned instead."
+    requested_visibility RequestedVisibility?
+        "The shared link's requested visibility. This can be overridden by the team and shared
+        folder policies. The final visibility, after considering these policies, can be found in
+        :field:`resolved_visibility`. This is shown only if the caller is the link's
+        owner and resolved_visibility is returned instead of effective_audience."
+    can_revoke Boolean
+        "Whether the caller can revoke the shared link."
+    revoke_failure_reason SharedLinkAccessFailureReason?
+        "The failure reason for revoking the link. This field will only be present if the
+        :field:`can_revoke` is :val:`false`."
+    effective_audience LinkAudience?
+        "The type of audience who can benefit from the access level specified by the
+        `link_access_level` field."
+    link_access_level LinkAccessLevel?
+        "The access level that the link will grant to its users. A link can grant additional rights
+        to a user beyond their current access level. For example, if a user was invited as a viewer
+        to a file, and then opens a link with `link_access_level` set to `editor`, then they will
+        gain editor privileges. The `link_access_level` is a property of the link, and does not
+        depend on who is calling this API. In particular, `link_access_level` does not take into
+        account the API caller's current permissions to the content."
+    visibility_policies List(VisibilityPolicy)
+        "A list of policies that the user might be able to set for the visibility."
+    can_set_expiry Boolean
+        "Whether the user can set the expiry settings of the link. This refers to the ability to
+        create a new expiry and modify an existing expiry."
+    can_remove_expiry Boolean
+        "Whether the user can remove the expiry of the link."
+    allow_download Boolean
+        "Whether the link can be downloaded or not."
+    can_allow_download Boolean
+        "Whether the user can allow downloads via the link. This refers to the ability to remove a
+        no-download restriction on the link."
+    can_disallow_download Boolean
+        "Whether the user can disallow downloads via the link. This refers to the ability to impose
+        a no-download restriction on the link."
+    allow_comments Boolean
+        @common.Deprecated
+        "Whether comments are enabled for the linked file. This takes the team commenting policy into account."
+    team_restricts_comments Boolean
+        @common.Deprecated
+        "Whether the team has disabled commenting globally."
+    audience_options List(LinkAudienceOption)?
+        "A list of link audience options the user might be able to set as the new audience."
+    can_set_password Boolean?
+        "Whether the user can set a password for the link."
+    can_remove_password Boolean?
+        "Whether the user can remove the password of the link."
+    require_password Boolean?
+        "Whether the user is required to provide a password to view the link."
+    can_use_extended_sharing_controls Boolean?
+        "Whether the user can use extended sharing controls, based on their account type."
+    can_sync Boolean?
+        "Whether a user can save the content to their Dropbox account."
+    can_request_access Boolean?
+        "Whether the user can request access to the content."
+    enforce_shared_link_password_policy team_policies.EnforceLinkPasswordPolicy?
+        "Whether the updated externally available shared link must have password set.
+        Not provided if the link is not team owned."
+    days_to_expire_policy team_policies.DefaultLinkExpirationDaysPolicy?
+        "Existing owning team's policy for default number of days from today to link's expiration.
+        Not provided if the link is not team owned."
+    change_shared_link_expiration_policy ChangeLinkExpirationPolicy?
+        "When owning team's policy :field:`change_shared_link_expiration_policy` is :field:`ChangeLinkExpirationPolicy.not_allowed`,
+        the updated externally available shared link expiration value cannot be less strict
+        than :field:`days_to_expire_policy`.
+        In this case :field:`days_to_expire_policy` is expected to be different from `none`.
+        Not provided if the link is not team owned."
+
+    example default
+        resolved_visibility = public
+        can_revoke = false
+        revoke_failure_reason = owner_only
+        visibility_policies = [public, password]
+        can_set_expiry = false
+        can_remove_expiry = false
+        allow_download = true
+        can_allow_download = true
+        can_disallow_download = false
+        allow_comments = true
+        team_restricts_comments = true
+        audience_options = [public, team, no_one]
+        can_set_password = true
+        can_remove_password = true
+        require_password = false
+        can_use_extended_sharing_controls = false
+
+struct ListSharedLinksArg
+    path ReadPath?
+        "See :route:`list_shared_links` description."
+    cursor String?
+        "The cursor returned by your last call to :route:`list_shared_links`."
+    direct_only Boolean?
+        "See :route:`list_shared_links` description."
+
+    example default
+        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
+
+    example path
+        path = "/Homework/Math"
+
+    example id
+        path = "id:a4ayc_80_OEAAAAAAAAAYa"
+
+    example rev
+        path = "rev:a1c10ce0dd78"
+
+    example id_no_parent_links
+        path = "id:a4ayc_80_OEAAAAAAAAAYa"
+        direct_only = true
+
+struct ListSharedLinksResult
+    links List(SharedLinkMetadata)
+        "Shared links applicable to the path argument."
+    has_more Boolean
+        "Is true if there are additional shared links that have not been returned
+        yet. Pass the cursor into :route:`list_shared_links` to retrieve them."
+    cursor String?
+        "Pass the cursor into :route:`list_shared_links` to obtain the additional links. Cursor is
+        returned only if no path is given."
+
+    example default
+        links = [default]
+        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
+        has_more = true
+
+struct ModifySharedLinkSettingsArgs
+    url String
+        "URL of the shared link to change its settings."
+    settings SharedLinkSettings
+        "Set of settings for the shared link."
+    remove_expiration Boolean = false
+        "If set to true, removes the expiration of the shared link."
+
+    example default
+        url = "https://www.dropbox.com/s/2sn712vy1ovegw8/Prime_Numbers.txt?dl=0"
+        settings = default
+
+struct PathLinkMetadata extends LinkMetadata
+    "Metadata for a path-based shared link."
+    path String
+        "Path in user's Dropbox."
+
+    example default
+        url = "https://www.dropbox.com/s/2sn712vy1ovegw8/Prime_Numbers.txt?dl=0"
+        path = "/Homework/Math/Prime_Numbers.txt"
+        expires = null
+        visibility = public
+
+struct RevokeSharedLinkArg
+    url String
+        "URL of the shared link."
+
+    example default
+        url = "https://www.dropbox.com/s/2sn712vy1ovegw8/Prime_Numbers.txt?dl=0"
+
+struct SharedLinkSettings
+    require_password Boolean?
+        "Boolean flag to enable or disable password protection."
+    link_password String?
+        "If :field:`require_password` is true, this is needed
+        to specify the password to access the link."
+    expires common.DropboxTimestamp?
+        "Expiration time of the shared link. By default the link won't expire."
+    audience LinkAudience?
+        "The new audience who can benefit from the access level specified by the link's access level
+        specified in the `link_access_level` field of `LinkPermissions`. This is used in conjunction
+        with team policies and shared folder policies to determine the final effective audience type
+        in the `effective_audience` field of `LinkPermissions."
+    access RequestedLinkAccessLevel?
+        "Requested access level you want the audience to gain from this link. Note, modifying access
+        level for an existing link is not supported."
+    requested_visibility RequestedVisibility?
+        @common.Deprecated
+        "Use :field:`audience` instead.  The requested access for this shared link."
+    allow_download Boolean?
+        "Boolean flag to allow or not download capabilities for shared links."
+
+    example default
+        requested_visibility = public
+        audience = public
+        access = viewer
+        allow_download = true
+
+struct TeamMemberInfo
+    "Information about a team member."
+    team_info TeamInfo
+        "Information about the member's team."
+    display_name String
+        "The display name of the user."
+    member_id String?
+        "ID of user as a member of a team. This field will only be present if the member is in the
+        same team as current user."
+
+    example default
+        team_info = default
+        display_name = "Roger Rabbit"
+        member_id = "dbmid:abcd1234"
+
+struct VisibilityPolicy
+    policy RequestedVisibility
+        "This is the value to submit when saving the visibility setting."
+    resolved_policy AlphaResolvedVisibility
+        "This is what the effective policy would be, if you selected this option. The resolved
+        policy is obtained after considering external effects such as shared folder settings and
+        team policy. This value is guaranteed to be provided."
+    allowed Boolean
+        "Whether the user is permitted to set the visibility to this policy."
+    disallowed_reason VisibilityPolicyDisallowedReason?
+        "If :field:`allowed` is :val:`false`, this will provide the reason that the user is not
+        permitted to set the visibility to this policy."
+
+    example public
+        policy = public
+        resolved_policy = public
+        allowed = true
+
+    example public_team
+        policy = public
+        resolved_policy = team_only
+        allowed = false
+        disallowed_reason = restricted_by_team
+
+    example public_shared_folder
+        policy = public
+        resolved_policy = shared_folder_only
+        allowed = false
+        disallowed_reason = restricted_by_shared_folder
+
+    example password
+        policy = password
+        resolved_policy = password
+        allowed = true
+
+    example password_team
+        policy = password
+        resolved_policy = team_and_password
+        allowed = true
+
+    example password_shared_folder
+        policy = password
+        resolved_policy = shared_folder_only
+        allowed = false
+        disallowed_reason = restricted_by_shared_folder
+
+    example team_only
+        policy = team_only
+        resolved_policy = team_only
+        allowed = true
+
+    example team_shared_folder
+        policy = team_only
+        resolved_policy = shared_folder_only
+        allowed = false
+        disallowed_reason = restricted_by_shared_folder
+
+
+union AccessLevel
+    "Defines the access levels for collaborators."
+    owner
+        "The collaborator is the owner of the shared folder. Owners can
+        view and edit the shared folder as well as set the folder's
+        policies using :route:`update_folder_policy`."
+    editor
+        "The collaborator can both view and edit the shared folder."
+    viewer
+        "The collaborator can only view the shared folder."
+    viewer_no_comment
+        "The collaborator can only view the shared folder and does
+        not have any access to comments."
+    traverse
+        "The collaborator can only view the shared folder that they have
+        access to."
+    no_access
+        "If there is a Righteous Link on the folder which grants access
+        and the user has visited such link, they are allowed to perform
+        certain action (i.e. add themselves to the folder) via the link
+        access even though the user themselves are not a member on the
+        shared folder yet."
+
+struct InsufficientPlan
+    message String
+        "A message to tell the user to upgrade in order to support expected action."
+    upsell_url String?
+        "A URL to send the user to in order to obtain the account type they need, e.g. upgrading.
+        Absent if there is no action the user can take to upgrade."
+
+union PermissionDeniedReason
+    "Possible reasons the user is denied a permission."
+    user_not_same_team_as_owner
+        "User is not on the same team as the folder owner."
+    user_not_allowed_by_owner
+        "User is prohibited by the owner from taking the action."
+    target_is_indirect_member
+        "Target is indirectly a member of the folder, for example by being part of a group."
+    target_is_owner
+        "Target is the owner of the folder."
+    target_is_self
+        "Target is the user itself."
+    target_not_active
+        "Target is not an active member of the team."
+    folder_is_limited_team_folder
+        "Folder is team folder for a limited team."
+    owner_not_on_team
+        "The content owner needs to be on a Dropbox team to perform this action."
+    permission_denied
+        "The user does not have permission to perform this action on the link."
+    restricted_by_team
+        "The user's team policy prevents performing this action on the link."
+    user_account_type
+        "The user's account type does not support this action."
+    user_not_on_team
+        "The user needs to be on a Dropbox team to perform this action."
+    folder_is_inside_shared_folder
+        "Folder is inside of another shared folder."
+    restricted_by_parent_folder
+        "Policy cannot be changed due to restrictions from parent folder."
+    insufficient_plan InsufficientPlan
+
+
+route list_file_members/batch (ListFileMembersBatchArg, List(ListFileMembersBatchResult), SharingUserError)
+    "Get members of multiple files at once. The arguments
+    to this route are more limited, and the limit on query result size per file
+    is more strict. To customize the results more, use the individual file
+    endpoint.
+    Inherited users and groups are not included in the result, and permissions are not
+    returned for this endpoint."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
+        select_admin_mode = "whole_team"
+
+
+route add_file_member (AddFileMemberArgs, List(FileMemberActionResult), AddFileMemberError)
+    "Adds specified members to a file."
+
+    attrs
+        auth = "user"
+        scope = "sharing.write"
+        select_admin_mode = "team_admin"
+
+route get_file_metadata/batch (GetFileMetadataBatchArg, List(GetFileMetadataBatchResult), SharingUserError)
+    "Returns shared file metadata."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
+        select_admin_mode = "team_admin"
+
+route list_file_members/continue (ListFileMembersContinueArg, SharedFileMembers, ListFileMembersContinueError)
+    "Once a cursor has been retrieved from :route:`list_file_members` or
+    :route:`list_file_members/batch`, use this to paginate through all shared file members."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
+        select_admin_mode = "whole_team"
+
+route list_received_files (ListFilesArg, ListFilesResult, SharingUserError)
+    "Returns a list of all files shared with current user."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
+        select_admin_mode = "team_admin"
+
+route list_received_files/continue (ListFilesContinueArg, ListFilesResult, ListFilesContinueError)
+    "Get more results with a cursor from :route:`list_received_files`."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
+
+route remove_file_member (RemoveFileMemberArg, FileMemberActionIndividualResult, RemoveFileMemberError) deprecated
+    "Identical to remove_file_member_2 but with less information returned."
+
+    attrs
+        auth = "user"
+        scope = "sharing.write"
+        select_admin_mode = "team_admin"
+
+route remove_file_member_2 (RemoveFileMemberArg, FileMemberRemoveActionResult, RemoveFileMemberError)
+    "Removes a specified member from the file."
+
+    attrs
+        auth = "user"
+        scope = "sharing.write"
+        select_admin_mode = "team_admin"
+
+route relinquish_file_membership (RelinquishFileMembershipArg, Void, RelinquishFileMembershipError)
+    "The current user relinquishes their membership in the designated file."
+
+    attrs
+        auth = "user"
+        scope = "sharing.write"
+        select_admin_mode = "team_admin"
+
+route relinquish_access (RelinquishAccessArg, RelinquishAccessResult, RelinquishAccessError)
+    "Removes all self-removable access from a file or folder for the current
+    user. Best-effort and idempotent: attempts to drop link-visitor associations
+    and explicit ACL membership."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "private:sharing.write"
+        select_admin_mode = "whole_team"
+
+route unshare_file (UnshareFileArg, Void, UnshareFileError)
+    "Remove all members from this file. Does not remove inherited members."
+
+    attrs
+        auth = "user"
+        scope = "sharing.write"
+        select_admin_mode = "team_admin"
+
+route update_file_member (UpdateFileMemberArgs, MemberAccessLevelResult, FileMemberActionError)
+    "Changes a member's access on a shared file."
+
+    attrs
+        auth = "user"
+        scope = "sharing.write"
+        select_admin_mode = "team_admin"
+
+route update_file_policy (UpdateFilePolicyArg, SharedFileMetadata, UpdateFilePolicyError)
+    "Update the viewer info policy of a file."
+
+    attrs
+        auth = "user"
+        scope = "sharing.write"
+
+
+alias PathOrId = String(min_length=1, pattern="((\/|id:).*|nspath:[0-9]+:.*)|ns:[0-9]+(/.*)?")
+
+union AddFileMemberError
+    "Errors for :route:`add_file_member`."
+    user_error SharingUserError
+    access_error SharingFileAccessError
+    rate_limit
+        "The user has reached the rate limit for invitations."
+    invalid_comment
+        "The custom message did not pass comment permissions checks."
+    banned_member
+        "The current user has been banned for abuse reasons."
+
+union FileAction
+    "Sharing actions that may be taken on files."
+    disable_viewer_info
+        "Disable viewer information on the file."
+    edit_contents
+        "Change or edit contents of the file."
+    enable_viewer_info
+        "Enable viewer information on the file."
+    invite_viewer
+        "Add a member with view permissions."
+    invite_viewer_no_comment
+        "Add a member with view permissions but no comment permissions."
+    invite_editor
+        "Add a member with edit permissions."
+    unshare
+        "Stop sharing this file."
+    relinquish_membership
+        "Relinquish one's own membership to the file."
+    share_link
+        @common.Deprecated
+        "Use create_view_link and create_edit_link instead."
+    create_link
+        @common.Deprecated
+        "Use create_view_link and create_edit_link instead."
+    create_view_link
+        "Create a shared link to a file that only allows users to view the content."
+    create_edit_link
+        "Create a shared link to a file that allows users to edit the content."
+
+    example default
+        edit_contents = null
+
+union FileErrorResult
+    file_not_found_error files.Id
+        "File specified by id was not found."
+    invalid_file_action_error files.Id
+        "User does not have permission to take the specified action on the file."
+    permission_denied_error files.Id
+        "User does not have permission to access file specified by file.Id."
+
+union FileMemberActionError
+    invalid_member
+        "Specified member was not found."
+    no_permission
+        "User does not have permission to perform this action on this member."
+    access_error SharingFileAccessError
+        "Specified file was invalid or user does not have access."
+    no_explicit_access MemberAccessLevelResult
+        "The action cannot be completed because the target member does not have explicit access
+        to the file. The return value is the access that the member has to the file from a parent folder."
+
+union_closed FileMemberActionIndividualResult
+    success AccessLevel?
+        "Part of the response for both add_file_member and remove_file_member_v1 (deprecated).
+        For add_file_member, indicates giving access was successful and at what AccessLevel.
+        For remove_file_member_v1, indicates member was successfully removed from the file. If AccessLevel is given,
+        the member still has access via a parent shared folder."
+    member_error FileMemberActionError
+        "User was not able to perform this action."
+
+    example default
+        success = null
+
+union FileMemberRemoveActionResult
+    success MemberAccessLevelResult
+        "Member was successfully removed from this file."
+    member_error FileMemberActionError
+        "User was not able to remove this member."
+
+union GetFileMetadataError
+    "Error result for :route:`get_file_metadata`."
+    user_error SharingUserError
+    access_error SharingFileAccessError
+
+union GetFileMetadataIndividualResult
+    metadata SharedFileMetadata
+        "The result for this file if it was successful."
+    access_error SharingFileAccessError
+        "The result for this file if it was an error."
+
+    example default
+        metadata = default
+
+    example file_error
+        access_error = invalid_file
+
+union ListFileMembersContinueError
+    "Error for :route:`list_file_members/continue`."
+    user_error SharingUserError
+    access_error SharingFileAccessError
+    invalid_cursor
+        ":field:`ListFileMembersContinueArg.cursor` is invalid."
+
+union ListFileMembersError
+    "Error for :route:`list_file_members`."
+    user_error SharingUserError
+    access_error SharingFileAccessError
+
+union ListFileMembersIndividualResult
+    result ListFileMembersCountResult
+        "The results of the query for this file if it was successful."
+    access_error SharingFileAccessError
+        "The result of the query for this file if it was an error."
+
+    example default
+        result = default
+
+    example file_error
+        access_error = invalid_file
+
+union ListFilesContinueError
+    "Error results for :route:`list_received_files/continue`."
+    user_error SharingUserError
+        "User account had a problem."
+    invalid_cursor
+        ":field:`ListFilesContinueArg.cursor` is invalid."
+
+union RelinquishFileMembershipError
+    access_error SharingFileAccessError
+    group_access
+        "The current user has access to the shared file via a group.  You can't relinquish
+        membership to a file shared via groups."
+    no_permission
+        "The current user does not have permission to perform this action."
+
+union RelinquishAccessError
+    "Error result for the relinquish_access endpoint."
+    invalid_file_id
+        "File or folder not found or has been deleted."
+    email_unverified
+        "Caller's email address is not verified."
+    owner
+        "User is the owner of the file/folder."
+    no_explicit_access
+        "User has only non-removable access — inherited from a parent folder
+        or via group membership. Either way, relinquish_access cannot remove
+        the caller's access from this surface; the caller must take action
+        on the source of the access (e.g. leave the parent shared folder,
+        or be removed from the group)."
+    team_folder
+        "Team folder restrictions apply."
+    no_permission
+        "Caller does not have permission to perform this action. Generic fallback."
+
+union UpdateFilePolicyError
+    "Error result for :route:`update_file_policy`."
+    access_error SharingFileAccessError
+    invalid_file_settings
+        "The file settings are invalid."
+    no_permission
+        "The current user does not have permission to perform this action."
+
+union RemoveFileMemberError
+    "Errors for :route:`remove_file_member_2`."
+    user_error SharingUserError
+    access_error SharingFileAccessError
+    no_explicit_access MemberAccessLevelResult
+        "This member does not have explicit access to the file and therefore cannot be removed.
+        The return value is the access that a user might have to the file from a parent folder."
+
+union SharingFileAccessError
+    "User could not access this file."
+    no_permission
+        "Current user does not have sufficient privileges to perform the desired action."
+    invalid_file
+        "File specified was not found."
+    is_folder
+        "A folder can't be shared this way. Use folder sharing or a shared link instead."
+    inside_public_folder
+        "A file inside a public folder can't be shared this way. Use a public link instead."
+    inside_osx_package
+        "A Mac OS X package can't be shared this way. Use a shared link instead."
+
+union SharingUserError
+    "User account had a problem preventing this action."
+    email_unverified
+        "This user's email address is not verified. This functionality is only
+        available on accounts with a verified email address. Users can verify
+        their email address :link:`here https://www.dropbox.com/help/317`."
+
+union UnshareFileError
+    "Error result for :route:`unshare_file`."
+    user_error SharingUserError
+    access_error SharingFileAccessError
+
+    example default
+        user_error = email_unverified
+
+struct AddFileMemberArgs
+    "Arguments for :route:`add_file_member`."
+    file PathOrId
+        "File to which to add members."
+    members List(MemberSelector)
+        "Members to add. Note that even an email address is given, this
+        may result in a user being directly added to the membership if that
+        email is the user's main account email."
+    custom_message String?
+        "Message to send to added members in their invitation."
+    quiet Boolean = false
+        "Whether added members should be notified via email and device notifications of
+        their invitation."
+    access_level AccessLevel?
+        "AccessLevel union object, describing what access level we want to give new members."
+    add_message_as_comment Boolean = false
+        "If the custom message should be added as a comment on the file. Only meant for Paper files."
+    fp_sealed_result String?
+        "The FingerprintJS Sealed Client Result value"
+
+    example default
+        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
+        members = [default]
+        custom_message = "This is a custom message about ACME.doc"
+        quiet = false
+        access_level = viewer
+
+struct FileMemberActionResult
+    "Per-member result for :route:`add_file_member`."
+    member MemberSelector
+        "One of specified input members."
+    result FileMemberActionIndividualResult
+        "The outcome of the action on this member."
+    sckey_sha1 String?
+        "The SHA-1 encrypted shared content key."
+    invitation_signature List(String)?
+        "The sharing sender-recipient invitation signatures for the input member_id.
+        A member_id can be a group and thus have multiple users and multiple invitation signatures."
+
+    example default
+        member = default
+        result = default
+        sckey_sha1 = "32gggb672f987b2d94ef1741616bdf37d565e8c1"
+        invitation_signature = ["32gggb672f987b2d94ef1741616bdf37d565e8c1:c1ce0a9ef6ggg65e6e2f43514082ea5ffefd9cf5"]
+
+struct FilePermission
+    "Whether the user is allowed to take the sharing action on the file."
+    action FileAction
+        "The action that the user may wish to take on the file."
+    allow Boolean
+        "True if the user is allowed to take the action."
+    reason PermissionDeniedReason?
+        "The reason why the user is denied the permission. Not present if the action
+        is allowed."
+
+    example default
+        action = edit_contents
+        allow = false
+        reason = user_not_same_team_as_owner
+
+struct GetFileMetadataArg
+    "Arguments of :route:`get_file_metadata`."
+    file PathOrId
+        "The file to query."
+    actions List(FileAction)?
+        "A list of `FileAction`s corresponding to `FilePermission`s that should appear in the
+        response's :field:`SharedFileMetadata.permissions` field describing the actions the
+        authenticated user can perform on the file."
+
+    example default
+        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
+        actions = []
+
+struct GetFileMetadataBatchArg
+    "Arguments of :route:`get_file_metadata/batch`."
+    files List(PathOrId, max_items=100)
+        "The files to query."
+    actions List(FileAction)?
+        "A list of `FileAction`s corresponding to `FilePermission`s that should appear in the
+        response's :field:`SharedFileMetadata.permissions` field describing the actions the
+        authenticated user can perform on the file."
+
+    example default
+        files = ["id:3kmLmQFnf1AAAAAAAAAAAw","id:VvTaJu2VZzAAAAAAAAAADQ"]
+        actions = []
+
+struct GetFileMetadataBatchResult
+    "Per file results of :route:`get_file_metadata/batch`."
+    file PathOrId
+        "This is the input file identifier corresponding to one of
+        :field:`GetFileMetadataBatchArg.files`."
+    result GetFileMetadataIndividualResult
+        "The result for this particular file."
+
+    example default
+        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
+        result = default
+
+    example file_error
+        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
+        result = file_error
+
+struct ListFileMembersArg
+    "Arguments for :route:`list_file_members`."
+    file PathOrId
+        "The file for which you want to see members."
+    actions List(MemberAction)?
+        "The actions for which to return permissions on a member."
+    include_inherited Boolean = true
+        "Whether to include members who only have access from a parent shared folder."
+    limit UInt32(max_value=300, min_value=1) = 100
+        "Number of members to return max per query. Defaults to 100 if no limit is specified."
+
+    example default
+        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
+
+struct ListFileMembersBatchArg
+    "Arguments for :route:`list_file_members/batch`."
+    files List(PathOrId, max_items=100)
+        "Files for which to return members."
+    limit UInt32(max_value=3000) = 1000
+        "Number of members to return max per query. Defaults to 1000 if no limit is specified."
+
+    example default
+        files = ["id:3kmLmQFnf1AAAAAAAAAAAw","id:VvTaJu2VZzAAAAAAAAAADQ"]
+        limit = 1000
+
+struct ListFileMembersBatchResult
+    "Per-file result for :route:`list_file_members/batch`."
+    file PathOrId
+        "This is the input file identifier, whether an ID or a path."
+    result ListFileMembersIndividualResult
+        "The result for this particular file."
+
+    example default
+        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
+        result = default
+
+    example member_error
+        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
+        result = file_error
+
+struct ListFileMembersContinueArg
+    "Arguments for :route:`list_file_members/continue`."
+    cursor String
+        "The cursor returned by your last call to :route:`list_file_members`,
+        :route:`list_file_members/continue`, or :route:`list_file_members/batch`."
+
+    example default
+        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
+
+struct ListFileMembersCountResult
+    members SharedFileMembers
+        "A list of members on this file."
+    member_count UInt32
+        "The number of members on this file. This does not include inherited members."
+
+    example default
+        members = default
+        member_count = 3
+
+struct ListFilesArg
+    "Arguments for :route:`list_received_files`."
+    limit UInt32(max_value=300, min_value=1) = 100
+        "Number of files to return max per query. Defaults to 100 if no limit
+        is specified."
+    actions List(FileAction)?
+        "A list of `FileAction`s corresponding to `FilePermission`s that should appear in the
+        response's :field:`SharedFileMetadata.permissions` field describing the actions the
+        authenticated user can perform on the file."
+
+    example default
+        limit = 100
+        actions = []
+
+struct ListFilesContinueArg
+    "Arguments for :route:`list_received_files/continue`."
+    cursor String
+        "Cursor in :field:`ListFilesResult.cursor`."
+
+    example default
+        cursor = "AzJJbGlzdF90eXBdofe9c3RPbGlzdGFyZ3NfYnlfZ2lkMRhcbric7Rdog9emfGRlc2MCRWxpbWl0BGRId"
+
+struct ListFilesResult
+    "Success results for :route:`list_received_files`."
+    entries List(SharedFileMetadata)
+        "Information about the files shared with current user."
+    cursor String?
+        "Cursor used to obtain additional shared files."
+
+    example default
+        entries = [default]
+        cursor = "AzJJbGlzdF90eXBdofe9c3RPbGlzdGFyZ3NfYnlfZ2lkMRhcbric7Rdog9cmV2aXNpb24H3Qf6o1fkHxQ"
+
+struct RelinquishFileMembershipArg
+    file PathOrId
+        "The path or id for the file."
+
+    example default
+        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
+
+struct RelinquishAccessArg
+    "Removes all self-removable access from a file or folder.
+    For folders: always relinquishes without keeping a local copy
+    (leave_a_copy=false behavior). If you need control over keeping
+    folder contents, use the relinquish_folder_membership endpoint instead."
+    file_id String
+        "The id for the file or folder."
+
+    example default
+        file_id = "id:3kmLmQFnf1AAAAAAAAAAAw"
+
+struct RelinquishAccessResult
+    "Returns an empty response for the relinquish_access endpoint."
+
+struct RemoveFileMemberArg
+    "Arguments for :route:`remove_file_member_2`."
+    file PathOrId
+        "File from which to remove members."
+    member MemberSelector
+        "Member to remove from this file. Note that even if an email is
+        specified, it may result in the removal of a user (not an invitee) if
+        the user's main account corresponds to that email address."
+
+    example default
+        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
+        member = default
+
+struct SharedFileMembers
+    "Shared file user, group, and invitee membership.
+    Used for the results of :route:`list_file_members` and
+    :route:`list_file_members/continue`, and used as part of the results
+    for :route:`list_file_members/batch`."
+    users List(UserFileMembershipInfo)
+        "The list of user members of the shared file."
+    groups List(GroupMembershipInfo)
+        "The list of group members of the shared file."
+    invitees List(InviteeMembershipInfo)
+        "The list of invited members of a file, but have not logged in and
+        claimed this."
+    cursor String?
+        "Present if there are additional shared file members that have not been returned yet. Pass
+        the cursor into :route:`list_file_members/continue` to list additional members."
+
+    example default
+        users = [default]
+        groups = [default]
+        invitees = [default]
+
+struct SharedFileMetadata
+    "Properties of the shared file."
+    access_type AccessLevel?
+        "The current user's access level for this shared file."
+    id files.FileId
+        "The ID of the file."
+    expected_link_metadata ExpectedSharedContentLinkMetadata?
+        "The expected metadata of the link associated for the file when it is first shared.
+        Absent if the link already exists. This is for an unreleased feature so it may not be
+        returned yet."
+    link_metadata SharedContentLinkMetadata?
+        "The metadata of the link associated for the file. This is for an unreleased feature so
+        it may not be returned yet."
+    name String
+        "The name of this file."
+    owner_display_names List(String)?
+        "The display names of the users that own the file. If the file is part
+        of a team folder, the display names of the team admins are also
+        included. Absent if the owner display names cannot be fetched."
+    owner_team users.Team?
+        "The team that owns the file. This field is not present if the file
+        is not owned by a team."
+    parent_shared_folder_id common.SharedFolderId?
+        "The ID of the parent shared folder. This field is present only if the
+        file is contained within a shared folder."
+    path_display String?
+        "The cased path to be used for display purposes only. In rare instances
+        the casing will not correctly match the user's filesystem, but this
+        behavior will match the path provided in the Core API v1.
+        Absent for unmounted files."
+    path_lower String?
+        "The lower-case full path of this file. Absent for unmounted files."
+    permissions List(FilePermission)?
+        "The sharing permissions that requesting user has on this file. This
+        corresponds to the entries given in :field:`GetFileMetadataBatchArg.actions`
+        or :field:`GetFileMetadataArg.actions`."
+    policy FolderPolicy
+        "Policies governing this shared file."
+    preview_url String
+        "URL for displaying a web preview of the shared file."
+    time_invited common.DropboxTimestamp?
+        "Timestamp indicating when the current user was invited to this shared file. If the user was
+        not invited to the shared file, the timestamp will indicate when the user was invited to the
+        parent shared folder. This value may be absent."
+
+    example default
+        policy = default
+        permissions = []
+        owner_display_names = ["Jane Doe"]
+        owner_team = default
+        preview_url = "https://www.dropbox.com/scl/fi/fir9vjelf"
+        path_lower = "/dir/file.txt"
+        path_display = "/dir/file.txt"
+        name = "file.txt"
+        id = "id:3kmLmQFnf1AAAAAAAAAAAw"
+        time_invited = "2016-01-20T00:00:00Z"
+        access_type = viewer
+
+struct UnshareFileArg
+    "Arguments for :route:`unshare_file`."
+    file PathOrId
+        "The file to unshare."
+
+    example default
+        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
+
+struct UpdateFileMemberArgs
+    "Arguments for :route:`update_file_member`."
+    file PathOrId
+        "File for which we are changing a member's access."
+    member MemberSelector
+        "The member whose access we are changing."
+    access_level AccessLevel
+        "The new access level for the member."
+
+    example default
+        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
+        member = default
+        access_level = viewer
+
+struct UpdateFilePolicyArg
+    "Arguments for :route:`update_file_policy`."
+    file PathOrId
+        "File that we are changing the policy for."
+    actions List(FileAction)?
+        "A list of `FileAction`s corresponding to `FilePermission`s that should appear in the
+        response's :field:`SharedFileMetadata.permissions` field describing the actions the
+        authenticated user can perform on the file."
+    link_settings LinkSettings?
+        @common.Deprecated
+        "Settings on the link for the file."
+    viewer_info_policy ViewerInfoPolicy?
+        "The presence and seen state policy on the file."
+
+    example default
+        file = "/root/word.docx"
+
+struct UserFileMembershipInfo extends UserMembershipInfo
+    "The information about a user member of the shared content with an appended last seen timestamp."
+    time_last_seen common.DropboxTimestamp?
+        "The UTC timestamp of when the user has last seen the content. Only populated if the
+        user has seen the content and the caller has a plan that includes viewer history."
+    platform_type seen_state.PlatformType?
+        "The platform on which the user has last seen the content, or unknown."
+
+    example default
+        user = default
+        access_type = owner
+        permissions = []
+        time_last_seen = "2016-01-20T00:00:00Z"
+        platform_type = unknown
+
+
+alias DropboxId = String(min_length=1)
+
+union MemberPolicy
+    "Policy governing who can be a member of a shared folder. Only applicable
+    to folders owned by a user on a team."
+    team
+        "Only a teammate can become a member."
+    anyone
+        "Anyone can become a member."
+    team_and_approved
+        "Only a teammate and approved people can become a member."
+
+union AclUpdatePolicy
+    "Who can change a shared folder's access control list (ACL). In other words, who can add,
+    remove, or change the privileges of members."
+    owner
+        "Only the owner can update the ACL."
+    editors
+        "Any editor can update the ACL. This may be further restricted to
+        editors on the same team."
+
+union SharedLinkPolicy
+    "Who can view shared links in this folder."
+    anyone
+        "Links can be shared with anyone."
+    team
+        @common.Deprecated
+        "Links can be shared with anyone on the same team as the owner."
+    members
+        "Links can only be shared among members of the shared folder."
+
+union ViewerInfoPolicy
+    enabled
+        "Viewer information is available on this file."
+    disabled
+        "Viewer information is disabled on this file."
+
+struct FolderPolicy
+    "A set of policies governing membership and privileges for a shared
+    folder."
+    member_policy MemberPolicy?
+        "Who can be a member of this shared folder, as set on the folder itself.
+        The effective policy may differ from this value if the team-wide policy
+        is more restrictive. Present only if the folder is owned by a team."
+    resolved_member_policy MemberPolicy?
+        "Who can be a member of this shared folder, taking into account both the
+        folder and the team-wide policy. This value may differ from that of
+        member_policy if the team-wide policy is more restrictive than the folder
+        policy. Present only if the folder is owned by a team."
+    acl_update_policy AclUpdatePolicy
+        "Who can add and remove members from this shared folder."
+    shared_link_policy SharedLinkPolicy
+        "Who links can be shared with."
+    viewer_info_policy ViewerInfoPolicy?
+        "Who can enable/disable viewer info for this shared folder."
+
+    example default
+        member_policy = anyone
+        resolved_member_policy = team
+        acl_update_policy = owner
+        shared_link_policy = anyone
+
+union FolderAction
+    "Actions that may be taken on shared folders."
+    change_options
+        "Change folder options, such as who can be invited to join the folder."
+    disable_viewer_info
+        "Disable viewer information for this folder."
+    edit_contents
+        "Change or edit contents of the folder."
+    enable_viewer_info
+        "Enable viewer information on the folder."
+    invite_editor
+        "Invite a user or group to join the folder with read and write permission."
+    invite_viewer
+        "Invite a user or group to join the folder with read permission."
+    invite_viewer_no_comment
+        "Invite a user or group to join the folder with read permission but no comment permissions."
+    relinquish_membership
+        "Relinquish one's own membership in the folder."
+    unmount
+        "Unmount the folder."
+    unshare
+        "Stop sharing this folder."
+    leave_a_copy
+        "Keep a copy of the contents upon leaving or being kicked from the folder."
+    share_link
+        @common.Deprecated
+        "Use create_view_link and create_edit_link instead."
+    create_link
+        @common.Deprecated
+        "Use create_view_link and create_edit_link instead."
+    create_view_link
+        "Create a shared link that only allows users to view the content."
+    create_edit_link
+        "Create a shared link that allows users to edit the content."
+    set_access_inheritance
+        "Set whether the folder inherits permissions from its parent."
+
+struct SharedFolderMetadataBase
+    "Properties of the shared folder."
+    access_type AccessLevel
+        "The current user's access level for this shared folder."
+    is_inside_team_folder Boolean
+        "Whether this folder is inside of a team folder."
+    is_team_folder Boolean
+        "Whether this folder is a
+        :link:`team folder https://www.dropbox.com/en/help/986`."
+    owner_display_names List(String)?
+        "The display names of the users that own the folder. If the folder is
+        part of a team folder, the display names of the team admins are also
+        included. Absent if the owner display names cannot be fetched."
+    owner_team users.Team?
+        "The team that owns the folder. This field is not present if the folder
+        is not owned by a team."
+    parent_shared_folder_id common.SharedFolderId?
+        "The ID of the parent shared folder. This field is present only if the
+        folder is contained within another shared folder."
+    path_display String?
+        "The full path of this shared folder. Absent for unmounted folders."
+    path_lower String?
+        "The lower-cased full path of this shared folder. Absent for unmounted folders."
+    parent_folder_name String?
+        "Display name for the parent folder."
+
+    example default
+        access_type = owner
+        is_inside_team_folder = false
+        is_team_folder = false
+        owner_display_names = ["Jane Doe"]
+        owner_team = default
+        parent_folder_name = "Parent Shared Folder"
+
+
 struct MemberPermission
     "Whether the user is allowed to take the action on the associated member."
     action MemberAction
@@ -65,10 +1850,10 @@ union MemberSelector
 
     example default
         email = "justin@example.com"
-    
+
     example account
         dropbox_id = "dbid:AAEufNrMPSPe0dMQijRP0N_aZtBJRm26W4Q"
-    
+
     example group
         dropbox_id = "g:98d36ed08e6290c2e9d536a392f974ee"
 
@@ -96,6 +1881,7 @@ struct MembershipInfo
         "The permissions that requesting user has on this member. The set of
         permissions corresponds to the MemberActions in the request."
     initials String?
+        @common.Deprecated
         "Never set."
     is_inherited Boolean = false
         "True if the member has access on a parent folder."
@@ -110,6 +1896,7 @@ struct GroupInfo extends team_common.GroupSummary
     "The information about a group. Groups is a way to manage a list of users
     who need same access permission to the shared folder."
     group_type team_common.GroupType
+        @common.Deprecated
         "The type of group."
     is_member Boolean
         "If the current user is a member of the group."
@@ -227,11 +2014,12 @@ union AddFolderMemberError
     no_permission
         "The current user does not have permission to perform this action."
     invalid_shared_folder
+        @common.Deprecated
         "Invalid shared folder error will be returned as an access_error."
 
     example default
         no_permission = null
-    
+
     example member
         bad_member = default
 
@@ -483,6 +2271,7 @@ union SharedFolderAccessError
     invalid_member
         "The user does not exist or their account is disabled."
     email_unverified
+        @common.Deprecated
         "Never set."
     unmounted
         "The shared folder is unmounted."
@@ -589,7 +2378,7 @@ struct AddMember
     example default
         member = default
         access_level = editor
-    
+
     example account
         member = account
         access_level = viewer
@@ -640,13 +2429,13 @@ struct ListFolderMembersArgs extends ListFolderMembersCursorArg
         shared_folder_id = "84528192421"
         actions = []
         limit = 10
-    
+
     example with_path_id
         shared_folder_id = "67890"
         path = "ns:67890/Documents/Folder"
         actions = []
         limit = 10
-    
+
     example with_full_path
         shared_folder_id = "84528192421"
         path = "/Users/john/Dropbox/Documents/Folder"
@@ -919,1770 +2708,6 @@ struct UpdateFolderPolicyArg
         shared_link_policy = members
 
 
-route list_shared_links (ListSharedLinksArg, ListSharedLinksResult, ListSharedLinksError)
-    "List shared links of this user.
-    If no path is given, returns a list of all shared links for the current user. For members of
-    business teams using team space and member folders, returns all shared links in the team
-    member's home folder unless the team space ID is specified in the request header.
-    If a non-empty path is given, returns a list of all shared links that allow access to the
-    given path - direct links to the given path and links to parent folders of the given path.
-    Links to parent folders can be suppressed by setting direct_only to true."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "sharing.read"
-        select_admin_mode = "whole_team"
-
-
-route create_shared_link (CreateSharedLinkArg, PathLinkMetadata, CreateSharedLinkError) deprecated
-    "Create a shared link.
-    If a shared link already exists for the given path, that link is returned.
-    Previously, it was technically possible to break a shared link by moving or
-    renaming the corresponding file or folder. In the future, this will no
-    longer be the case, so your app shouldn't rely on this behavior. Instead, if
-    your app needs to revoke a shared link, use revoke_shared_link.
-    DEPRECATED: Use create_shared_link_with_settings instead."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "sharing.write"
-        select_admin_mode = "team_admin"
-
-route get_shared_links (GetSharedLinksArg, GetSharedLinksResult, GetSharedLinksError) deprecated
-    "Returns a list of :type:`LinkMetadata` objects for this user, including collection links.
-    If no path is given, returns a list of all shared links for the current user,
-    including collection links, up to a maximum of 1000 links.
-    If a non-empty path is given, returns a list of all shared links that allow access
-    to the given path. Collection links are never returned in this case.
-    DEPRECATED: Use list_shared_links instead."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "sharing.read"
-
-route revoke_shared_link (RevokeSharedLinkArg, Void, RevokeSharedLinkError)
-    "Revoke a shared link.
-    Note that even after revoking a shared link to a file, the file may be accessible if there are
-    shared links leading to any of the file parent folders. To list all shared links that enable
-    access to a specific file, you can use the list_shared_links with the file as the
-    ListSharedLinksArg.path argument."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "sharing.write"
-        select_admin_mode = "team_admin"
-
-
-alias PathOrId = String(min_length=1, pattern="((\/|id:).*|nspath:[0-9]+:.*)|ns:[0-9]+(/.*)?")
-
-union AddFileMemberError
-    "Errors for :route:`add_file_member`."
-    user_error SharingUserError
-    access_error SharingFileAccessError
-    rate_limit
-        "The user has reached the rate limit for invitations."
-    invalid_comment
-        "The custom message did not pass comment permissions checks."
-    banned_member
-        "The current user has been banned for abuse reasons."
-
-union FileAction
-    "Sharing actions that may be taken on files."
-    disable_viewer_info
-        "Disable viewer information on the file."
-    edit_contents
-        "Change or edit contents of the file."
-    enable_viewer_info
-        "Enable viewer information on the file."
-    invite_viewer
-        "Add a member with view permissions."
-    invite_viewer_no_comment
-        "Add a member with view permissions but no comment permissions."
-    invite_editor
-        "Add a member with edit permissions."
-    unshare
-        "Stop sharing this file."
-    relinquish_membership
-        "Relinquish one's own membership to the file."
-    share_link
-        "Use create_view_link and create_edit_link instead."
-    create_link
-        "Use create_view_link and create_edit_link instead."
-    create_view_link
-        "Create a shared link to a file that only allows users to view the content."
-    create_edit_link
-        "Create a shared link to a file that allows users to edit the content."
-
-    example default
-        edit_contents = null
-
-union FileErrorResult
-    file_not_found_error files.Id
-        "File specified by id was not found."
-    invalid_file_action_error files.Id
-        "User does not have permission to take the specified action on the file."
-    permission_denied_error files.Id
-        "User does not have permission to access file specified by file.Id."
-
-union FileMemberActionError
-    invalid_member
-        "Specified member was not found."
-    no_permission
-        "User does not have permission to perform this action on this member."
-    access_error SharingFileAccessError
-        "Specified file was invalid or user does not have access."
-    no_explicit_access MemberAccessLevelResult
-        "The action cannot be completed because the target member does not have explicit access
-        to the file. The return value is the access that the member has to the file from a parent folder."
-
-union_closed FileMemberActionIndividualResult
-    success AccessLevel?
-        "Part of the response for both add_file_member and remove_file_member_v1 (deprecated).
-        For add_file_member, indicates giving access was successful and at what AccessLevel.
-        For remove_file_member_v1, indicates member was successfully removed from the file. If AccessLevel is given,
-        the member still has access via a parent shared folder."
-    member_error FileMemberActionError
-        "User was not able to perform this action."
-
-    example default
-        success = null
-
-union FileMemberRemoveActionResult
-    success MemberAccessLevelResult
-        "Member was successfully removed from this file."
-    member_error FileMemberActionError
-        "User was not able to remove this member."
-
-union GetFileMetadataError
-    "Error result for :route:`get_file_metadata`."
-    user_error SharingUserError
-    access_error SharingFileAccessError
-
-union GetFileMetadataIndividualResult
-    metadata SharedFileMetadata
-        "The result for this file if it was successful."
-    access_error SharingFileAccessError
-        "The result for this file if it was an error."
-
-    example default
-        metadata = default
-    
-    example file_error
-        access_error = invalid_file
-
-union ListFileMembersContinueError
-    "Error for :route:`list_file_members/continue`."
-    user_error SharingUserError
-    access_error SharingFileAccessError
-    invalid_cursor
-        ":field:`ListFileMembersContinueArg.cursor` is invalid."
-
-union ListFileMembersError
-    "Error for :route:`list_file_members`."
-    user_error SharingUserError
-    access_error SharingFileAccessError
-
-union ListFileMembersIndividualResult
-    result ListFileMembersCountResult
-        "The results of the query for this file if it was successful."
-    access_error SharingFileAccessError
-        "The result of the query for this file if it was an error."
-
-    example default
-        result = default
-    
-    example file_error
-        access_error = invalid_file
-
-union ListFilesContinueError
-    "Error results for :route:`list_received_files/continue`."
-    user_error SharingUserError
-        "User account had a problem."
-    invalid_cursor
-        ":field:`ListFilesContinueArg.cursor` is invalid."
-
-union RelinquishFileMembershipError
-    access_error SharingFileAccessError
-    group_access
-        "The current user has access to the shared file via a group.  You can't relinquish
-        membership to a file shared via groups."
-    no_permission
-        "The current user does not have permission to perform this action."
-
-union RelinquishAccessError
-    "Error result for the relinquish_access endpoint."
-    invalid_file_id
-        "File or folder not found or has been deleted."
-    email_unverified
-        "Caller's email address is not verified."
-    owner
-        "User is the owner of the file/folder."
-    no_explicit_access
-        "User only has inherited access from a parent folder."
-    group_access
-        "User has access only via group membership."
-    team_folder
-        "Team folder restrictions apply."
-    no_permission
-        "Caller does not have permission to perform this action. Generic fallback."
-
-union RemoveFileMemberError
-    "Errors for :route:`remove_file_member_2`."
-    user_error SharingUserError
-    access_error SharingFileAccessError
-    no_explicit_access MemberAccessLevelResult
-        "This member does not have explicit access to the file and therefore cannot be removed.
-        The return value is the access that a user might have to the file from a parent folder."
-
-union SharingFileAccessError
-    "User could not access this file."
-    no_permission
-        "Current user does not have sufficient privileges to perform the desired action."
-    invalid_file
-        "File specified was not found."
-    is_folder
-        "A folder can't be shared this way. Use folder sharing or a shared link instead."
-    inside_public_folder
-        "A file inside a public folder can't be shared this way. Use a public link instead."
-    inside_osx_package
-        "A Mac OS X package can't be shared this way. Use a shared link instead."
-
-union SharingUserError
-    "User account had a problem preventing this action."
-    email_unverified
-        "This user's email address is not verified. This functionality is only
-        available on accounts with a verified email address. Users can verify
-        their email address :link:`here https://www.dropbox.com/help/317`."
-
-union UnshareFileError
-    "Error result for :route:`unshare_file`."
-    user_error SharingUserError
-    access_error SharingFileAccessError
-
-    example default
-        user_error = email_unverified
-
-struct AddFileMemberArgs
-    "Arguments for :route:`add_file_member`."
-    file PathOrId
-        "File to which to add members."
-    members List(MemberSelector)
-        "Members to add. Note that even an email address is given, this
-        may result in a user being directly added to the membership if that
-        email is the user's main account email."
-    custom_message String?
-        "Message to send to added members in their invitation."
-    quiet Boolean = false
-        "Whether added members should be notified via email and device notifications of
-        their invitation."
-    access_level AccessLevel?
-        "AccessLevel union object, describing what access level we want to give new members."
-    add_message_as_comment Boolean = false
-        "If the custom message should be added as a comment on the file. Only meant for Paper files."
-    fp_sealed_result String?
-        "The FingerprintJS Sealed Client Result value"
-
-    example default
-        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
-        members = [default]
-        custom_message = "This is a custom message about ACME.doc"
-        quiet = false
-        access_level = viewer
-
-struct FileMemberActionResult
-    "Per-member result for :route:`add_file_member`."
-    member MemberSelector
-        "One of specified input members."
-    result FileMemberActionIndividualResult
-        "The outcome of the action on this member."
-    sckey_sha1 String?
-        "The SHA-1 encrypted shared content key."
-    invitation_signature List(String)?
-        "The sharing sender-recipient invitation signatures for the input member_id.
-        A member_id can be a group and thus have multiple users and multiple invitation signatures."
-
-    example default
-        member = default
-        result = default
-        sckey_sha1 = "32gggb672f987b2d94ef1741616bdf37d565e8c1"
-        invitation_signature = ["32gggb672f987b2d94ef1741616bdf37d565e8c1:c1ce0a9ef6ggg65e6e2f43514082ea5ffefd9cf5"]
-
-struct FilePermission
-    "Whether the user is allowed to take the sharing action on the file."
-    action FileAction
-        "The action that the user may wish to take on the file."
-    allow Boolean
-        "True if the user is allowed to take the action."
-    reason PermissionDeniedReason?
-        "The reason why the user is denied the permission. Not present if the action
-        is allowed."
-
-    example default
-        action = edit_contents
-        allow = false
-        reason = user_not_same_team_as_owner
-
-struct GetFileMetadataArg
-    "Arguments of :route:`get_file_metadata`."
-    file PathOrId
-        "The file to query."
-    actions List(FileAction)?
-        "A list of `FileAction`s corresponding to `FilePermission`s that should appear in the
-        response's :field:`SharedFileMetadata.permissions` field describing the actions the
-        authenticated user can perform on the file."
-
-    example default
-        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
-        actions = []
-
-struct GetFileMetadataBatchArg
-    "Arguments of :route:`get_file_metadata/batch`."
-    files List(PathOrId, max_items=100)
-        "The files to query."
-    actions List(FileAction)?
-        "A list of `FileAction`s corresponding to `FilePermission`s that should appear in the
-        response's :field:`SharedFileMetadata.permissions` field describing the actions the
-        authenticated user can perform on the file."
-
-    example default
-        files = ["id:3kmLmQFnf1AAAAAAAAAAAw","id:VvTaJu2VZzAAAAAAAAAADQ"]
-        actions = []
-
-struct GetFileMetadataBatchResult
-    "Per file results of :route:`get_file_metadata/batch`."
-    file PathOrId
-        "This is the input file identifier corresponding to one of
-        :field:`GetFileMetadataBatchArg.files`."
-    result GetFileMetadataIndividualResult
-        "The result for this particular file."
-
-    example default
-        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
-        result = default
-    
-    example file_error
-        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
-        result = file_error
-
-struct ListFileMembersArg
-    "Arguments for :route:`list_file_members`."
-    file PathOrId
-        "The file for which you want to see members."
-    actions List(MemberAction)?
-        "The actions for which to return permissions on a member."
-    include_inherited Boolean = true
-        "Whether to include members who only have access from a parent shared folder."
-    limit UInt32(max_value=300, min_value=1) = 100
-        "Number of members to return max per query. Defaults to 100 if no limit is specified."
-
-    example default
-        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
-
-struct ListFileMembersBatchArg
-    "Arguments for :route:`list_file_members/batch`."
-    files List(PathOrId, max_items=100)
-        "Files for which to return members."
-    limit UInt32(max_value=3000) = 1000
-        "Number of members to return max per query. Defaults to 1000 if no limit is specified."
-
-    example default
-        files = ["id:3kmLmQFnf1AAAAAAAAAAAw","id:VvTaJu2VZzAAAAAAAAAADQ"]
-        limit = 1000
-
-struct ListFileMembersBatchResult
-    "Per-file result for :route:`list_file_members/batch`."
-    file PathOrId
-        "This is the input file identifier, whether an ID or a path."
-    result ListFileMembersIndividualResult
-        "The result for this particular file."
-
-    example default
-        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
-        result = default
-    
-    example member_error
-        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
-        result = file_error
-
-struct ListFileMembersContinueArg
-    "Arguments for :route:`list_file_members/continue`."
-    cursor String
-        "The cursor returned by your last call to :route:`list_file_members`,
-        :route:`list_file_members/continue`, or :route:`list_file_members/batch`."
-
-    example default
-        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
-
-struct ListFileMembersCountResult
-    members SharedFileMembers
-        "A list of members on this file."
-    member_count UInt32
-        "The number of members on this file. This does not include inherited members."
-
-    example default
-        members = default
-        member_count = 3
-
-struct ListFilesArg
-    "Arguments for :route:`list_received_files`."
-    limit UInt32(max_value=300, min_value=1) = 100
-        "Number of files to return max per query. Defaults to 100 if no limit
-        is specified."
-    actions List(FileAction)?
-        "A list of `FileAction`s corresponding to `FilePermission`s that should appear in the
-        response's :field:`SharedFileMetadata.permissions` field describing the actions the
-        authenticated user can perform on the file."
-
-    example default
-        limit = 100
-        actions = []
-
-struct ListFilesContinueArg
-    "Arguments for :route:`list_received_files/continue`."
-    cursor String
-        "Cursor in :field:`ListFilesResult.cursor`."
-
-    example default
-        cursor = "AzJJbGlzdF90eXBdofe9c3RPbGlzdGFyZ3NfYnlfZ2lkMRhcbric7Rdog9emfGRlc2MCRWxpbWl0BGRId"
-
-struct ListFilesResult
-    "Success results for :route:`list_received_files`."
-    entries List(SharedFileMetadata)
-        "Information about the files shared with current user."
-    cursor String?
-        "Cursor used to obtain additional shared files."
-
-    example default
-        entries = [default]
-        cursor = "AzJJbGlzdF90eXBdofe9c3RPbGlzdGFyZ3NfYnlfZ2lkMRhcbric7Rdog9cmV2aXNpb24H3Qf6o1fkHxQ"
-
-struct RelinquishFileMembershipArg
-    file PathOrId
-        "The path or id for the file."
-
-    example default
-        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
-
-struct RelinquishAccessArg
-    "Removes all self-removable access from a file or folder.
-    For folders: always relinquishes without keeping a local copy
-    (leave_a_copy=false behavior). If you need control over keeping
-    folder contents, use the relinquish_folder_membership endpoint instead."
-    file_id String
-        "The id for the file or folder."
-
-    example default
-        file_id = "id:3kmLmQFnf1AAAAAAAAAAAw"
-
-struct RelinquishAccessResult
-    "Returns an empty response for the relinquish_access endpoint."
-
-struct RemoveFileMemberArg
-    "Arguments for :route:`remove_file_member_2`."
-    file PathOrId
-        "File from which to remove members."
-    member MemberSelector
-        "Member to remove from this file. Note that even if an email is
-        specified, it may result in the removal of a user (not an invitee) if
-        the user's main account corresponds to that email address."
-
-    example default
-        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
-        member = default
-
-struct SharedFileMembers
-    "Shared file user, group, and invitee membership.
-    Used for the results of :route:`list_file_members` and
-    :route:`list_file_members/continue`, and used as part of the results
-    for :route:`list_file_members/batch`."
-    users List(UserFileMembershipInfo)
-        "The list of user members of the shared file."
-    groups List(GroupMembershipInfo)
-        "The list of group members of the shared file."
-    invitees List(InviteeMembershipInfo)
-        "The list of invited members of a file, but have not logged in and
-        claimed this."
-    cursor String?
-        "Present if there are additional shared file members that have not been returned yet. Pass
-        the cursor into :route:`list_file_members/continue` to list additional members."
-
-    example default
-        users = [default]
-        groups = [default]
-        invitees = [default]
-
-struct SharedFileMetadata
-    "Properties of the shared file."
-    access_type AccessLevel?
-        "The current user's access level for this shared file."
-    id files.FileId
-        "The ID of the file."
-    expected_link_metadata ExpectedSharedContentLinkMetadata?
-        "The expected metadata of the link associated for the file when it is first shared.
-        Absent if the link already exists. This is for an unreleased feature so it may not be
-        returned yet."
-    link_metadata SharedContentLinkMetadata?
-        "The metadata of the link associated for the file. This is for an unreleased feature so
-        it may not be returned yet."
-    name String
-        "The name of this file."
-    owner_display_names List(String)?
-        "The display names of the users that own the file. If the file is part
-        of a team folder, the display names of the team admins are also
-        included. Absent if the owner display names cannot be fetched."
-    owner_team users.Team?
-        "The team that owns the file. This field is not present if the file
-        is not owned by a team."
-    parent_shared_folder_id common.SharedFolderId?
-        "The ID of the parent shared folder. This field is present only if the
-        file is contained within a shared folder."
-    path_display String?
-        "The cased path to be used for display purposes only. In rare instances
-        the casing will not correctly match the user's filesystem, but this
-        behavior will match the path provided in the Core API v1.
-        Absent for unmounted files."
-    path_lower String?
-        "The lower-case full path of this file. Absent for unmounted files."
-    permissions List(FilePermission)?
-        "The sharing permissions that requesting user has on this file. This
-        corresponds to the entries given in :field:`GetFileMetadataBatchArg.actions`
-        or :field:`GetFileMetadataArg.actions`."
-    policy FolderPolicy
-        "Policies governing this shared file."
-    preview_url String
-        "URL for displaying a web preview of the shared file."
-    time_invited common.DropboxTimestamp?
-        "Timestamp indicating when the current user was invited to this shared file. If the user was
-        not invited to the shared file, the timestamp will indicate when the user was invited to the
-        parent shared folder. This value may be absent."
-
-    example default
-        policy = default
-        permissions = []
-        owner_display_names = ["Jane Doe"]
-        owner_team = default
-        preview_url = "https://www.dropbox.com/scl/fi/fir9vjelf"
-        path_lower = "/dir/file.txt"
-        path_display = "/dir/file.txt"
-        name = "file.txt"
-        id = "id:3kmLmQFnf1AAAAAAAAAAAw"
-        time_invited = "2016-01-20T00:00:00Z"
-        access_type = viewer
-
-struct UnshareFileArg
-    "Arguments for :route:`unshare_file`."
-    file PathOrId
-        "The file to unshare."
-
-    example default
-        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
-
-struct UpdateFileMemberArgs
-    "Arguments for :route:`update_file_member`."
-    file PathOrId
-        "File for which we are changing a member's access."
-    member MemberSelector
-        "The member whose access we are changing."
-    access_level AccessLevel
-        "The new access level for the member."
-
-    example default
-        file = "id:3kmLmQFnf1AAAAAAAAAAAw"
-        member = default
-        access_level = viewer
-
-struct UserFileMembershipInfo extends UserMembershipInfo
-    "The information about a user member of the shared content with an appended last seen timestamp."
-    time_last_seen common.DropboxTimestamp?
-        "The UTC timestamp of when the user has last seen the content. Only populated if the
-        user has seen the content and the caller has a plan that includes viewer history."
-    platform_type seen_state.PlatformType?
-        "The platform on which the user has last seen the content, or unknown."
-
-    example default
-        user = default
-        access_type = owner
-        permissions = []
-        time_last_seen = "2016-01-20T00:00:00Z"
-        platform_type = unknown
-
-
-route add_file_member (AddFileMemberArgs, List(FileMemberActionResult), AddFileMemberError)
-    "Adds specified members to a file."
-
-    attrs
-        auth = "user"
-        scope = "sharing.write"
-        select_admin_mode = "team_admin"
-
-route get_file_metadata/batch (GetFileMetadataBatchArg, List(GetFileMetadataBatchResult), SharingUserError)
-    "Returns shared file metadata."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-        select_admin_mode = "team_admin"
-
-route list_file_members/continue (ListFileMembersContinueArg, SharedFileMembers, ListFileMembersContinueError)
-    "Once a cursor has been retrieved from :route:`list_file_members` or
-    :route:`list_file_members/batch`, use this to paginate through all shared file members."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-        select_admin_mode = "whole_team"
-
-route list_received_files (ListFilesArg, ListFilesResult, SharingUserError)
-    "Returns a list of all files shared with current user."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-        select_admin_mode = "team_admin"
-
-route list_received_files/continue (ListFilesContinueArg, ListFilesResult, ListFilesContinueError)
-    "Get more results with a cursor from :route:`list_received_files`."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-
-route remove_file_member (RemoveFileMemberArg, FileMemberActionIndividualResult, RemoveFileMemberError) deprecated
-    "Identical to remove_file_member_2 but with less information returned."
-
-    attrs
-        auth = "user"
-        scope = "sharing.write"
-        select_admin_mode = "team_admin"
-
-route remove_file_member_2 (RemoveFileMemberArg, FileMemberRemoveActionResult, RemoveFileMemberError)
-    "Removes a specified member from the file."
-
-    attrs
-        auth = "user"
-        scope = "sharing.write"
-        select_admin_mode = "team_admin"
-
-route relinquish_file_membership (RelinquishFileMembershipArg, Void, RelinquishFileMembershipError)
-    "The current user relinquishes their membership in the designated file."
-
-    attrs
-        auth = "user"
-        scope = "sharing.write"
-        select_admin_mode = "team_admin"
-
-route relinquish_access (RelinquishAccessArg, RelinquishAccessResult, RelinquishAccessError)
-    "Removes all self-removable access from a file or folder for the current
-    user. Best-effort and idempotent: attempts to drop link-visitor associations
-    and explicit ACL membership."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "private:sharing.write"
-        select_admin_mode = "whole_team"
-
-route unshare_file (UnshareFileArg, Void, UnshareFileError)
-    "Remove all members from this file. Does not remove inherited members."
-
-    attrs
-        auth = "user"
-        scope = "sharing.write"
-        select_admin_mode = "team_admin"
-
-route update_file_member (UpdateFileMemberArgs, MemberAccessLevelResult, FileMemberActionError)
-    "Changes a member's access on a shared file."
-
-    attrs
-        auth = "user"
-        scope = "sharing.write"
-        select_admin_mode = "team_admin"
-
-
-route list_file_members/batch (ListFileMembersBatchArg, List(ListFileMembersBatchResult), SharingUserError)
-    "Get members of multiple files at once. The arguments
-    to this route are more limited, and the limit on query result size per file
-    is more strict. To customize the results more, use the individual file
-    endpoint.
-    Inherited users and groups are not included in the result, and permissions are not
-    returned for this endpoint."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-        select_admin_mode = "whole_team"
-
-
-alias DropboxId = String(min_length=1)
-
-union MemberPolicy
-    "Policy governing who can be a member of a shared folder. Only applicable
-    to folders owned by a user on a team."
-    team
-        "Only a teammate can become a member."
-    anyone
-        "Anyone can become a member."
-    team_and_approved
-        "Only a teammate and approved people can become a member."
-
-union AclUpdatePolicy
-    "Who can change a shared folder's access control list (ACL). In other words, who can add,
-    remove, or change the privileges of members."
-    owner
-        "Only the owner can update the ACL."
-    editors
-        "Any editor can update the ACL. This may be further restricted to
-        editors on the same team."
-
-union SharedLinkPolicy
-    "Who can view shared links in this folder."
-    anyone
-        "Links can be shared with anyone."
-    team
-        "Links can be shared with anyone on the same team as the owner."
-    members
-        "Links can only be shared among members of the shared folder."
-
-union ViewerInfoPolicy
-    enabled
-        "Viewer information is available on this file."
-    disabled
-        "Viewer information is disabled on this file."
-
-struct FolderPolicy
-    "A set of policies governing membership and privileges for a shared
-    folder."
-    member_policy MemberPolicy?
-        "Who can be a member of this shared folder, as set on the folder itself.
-        The effective policy may differ from this value if the team-wide policy
-        is more restrictive. Present only if the folder is owned by a team."
-    resolved_member_policy MemberPolicy?
-        "Who can be a member of this shared folder, taking into account both the
-        folder and the team-wide policy. This value may differ from that of
-        member_policy if the team-wide policy is more restrictive than the folder
-        policy. Present only if the folder is owned by a team."
-    acl_update_policy AclUpdatePolicy
-        "Who can add and remove members from this shared folder."
-    shared_link_policy SharedLinkPolicy
-        "Who links can be shared with."
-    viewer_info_policy ViewerInfoPolicy?
-        "Who can enable/disable viewer info for this shared folder."
-
-    example default
-        member_policy = anyone
-        resolved_member_policy = team
-        acl_update_policy = owner
-        shared_link_policy = anyone
-
-union FolderAction
-    "Actions that may be taken on shared folders."
-    change_options
-        "Change folder options, such as who can be invited to join the folder."
-    disable_viewer_info
-        "Disable viewer information for this folder."
-    edit_contents
-        "Change or edit contents of the folder."
-    enable_viewer_info
-        "Enable viewer information on the folder."
-    invite_editor
-        "Invite a user or group to join the folder with read and write permission."
-    invite_viewer
-        "Invite a user or group to join the folder with read permission."
-    invite_viewer_no_comment
-        "Invite a user or group to join the folder with read permission but no comment permissions."
-    relinquish_membership
-        "Relinquish one's own membership in the folder."
-    unmount
-        "Unmount the folder."
-    unshare
-        "Stop sharing this folder."
-    leave_a_copy
-        "Keep a copy of the contents upon leaving or being kicked from the folder."
-    share_link
-        "Use create_view_link and create_edit_link instead."
-    create_link
-        "Use create_view_link and create_edit_link instead."
-    create_view_link
-        "Create a shared link that only allows users to view the content."
-    create_edit_link
-        "Create a shared link that allows users to edit the content."
-    set_access_inheritance
-        "Set whether the folder inherits permissions from its parent."
-
-struct SharedFolderMetadataBase
-    "Properties of the shared folder."
-    access_type AccessLevel
-        "The current user's access level for this shared folder."
-    is_inside_team_folder Boolean
-        "Whether this folder is inside of a team folder."
-    is_team_folder Boolean
-        "Whether this folder is a
-        :link:`team folder https://www.dropbox.com/en/help/986`."
-    owner_display_names List(String)?
-        "The display names of the users that own the folder. If the folder is
-        part of a team folder, the display names of the team admins are also
-        included. Absent if the owner display names cannot be fetched."
-    owner_team users.Team?
-        "The team that owns the folder. This field is not present if the folder
-        is not owned by a team."
-    parent_shared_folder_id common.SharedFolderId?
-        "The ID of the parent shared folder. This field is present only if the
-        folder is contained within another shared folder."
-    path_display String?
-        "The full path of this shared folder. Absent for unmounted folders."
-    path_lower String?
-        "The lower-cased full path of this shared folder. Absent for unmounted folders."
-    parent_folder_name String?
-        "Display name for the parent folder."
-
-    example default
-        access_type = owner
-        is_inside_team_folder = false
-        is_team_folder = false
-        owner_display_names = ["Jane Doe"]
-        owner_team = default
-        parent_folder_name = "Parent Shared Folder"
-
-
-route list_file_members (ListFileMembersArg, SharedFileMembers, ListFileMembersError)
-    "Use to obtain the members who have been invited to a file, both inherited
-    and uninherited members."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-        select_admin_mode = "whole_team"
-
-
-alias GetSharedLinkFileArg = GetSharedLinkMetadataArg
-
-alias Id = files.Id
-
-alias Path = files.Path
-
-alias ReadPath = files.ReadPath
-
-alias Rev = files.Rev
-
-alias TeamInfo = users.Team
-
-union AlphaResolvedVisibility extends ResolvedVisibility
-    "check documentation for ResolvedVisibility."
-
-union CreateSharedLinkError
-    path files.LookupError
-
-union_closed CreateSharedLinkWithSettingsError
-    path files.LookupError
-    email_not_verified
-        "This user's email address is not verified. This functionality is only
-        available on accounts with a verified email address. Users can verify
-        their email address :link:`here https://www.dropbox.com/help/317`."
-    shared_link_already_exists SharedLinkAlreadyExistsMetadata?
-        "The shared link already exists. You can call :route:`list_shared_links` to get the
-        existing link, or use the provided metadata if it is returned.
-        Existing link metadata will not be returned if custom settings were specified in the request that could make the existing link incompatible with the requested settings."
-    settings_error SharedLinkSettingsError
-        "There is an error with the given settings."
-    access_denied
-        "The user is not allowed to create a shared link to the specified file. For
-        example, this can occur if the file is restricted or if the user's links are
-        :link:`banned https://help.dropbox.com/files-folders/share/banned-links`."
-    banned_member
-        "The current user has been :link:`banned https://help.dropbox.com/files-folders/share/banned-links` for abuse reasons."
-    too_many_shared_folders
-        "Your Dropbox folder will have too many shared folders after the operation.
-        https://help.dropbox.com/share/shared-folder-faq#Is-there-a-limit-to-the-number-of-shared-folders-I-can-create"
-
-union GetSharedLinkFileError extends SharedLinkError
-    shared_link_is_directory
-        "Directories cannot be retrieved by this endpoint."
-
-union GetSharedLinksError
-    path files.MalformedPathError
-
-union LinkAccessLevel
-    viewer
-        "Users who use the link can view and comment on the content."
-    editor
-        "Users who use the link can edit, view and comment on the content."
-
-union LinkAudienceDisallowedReason extends VisibilityPolicyDisallowedReason
-    "check documentation for VisibilityPolicyDisallowedReason."
-
-union ListSharedLinksError
-    path files.LookupError
-    reset
-        "Indicates that the cursor has been invalidated. Call
-        :route:`list_shared_links` to obtain a new cursor."
-
-union ModifySharedLinkSettingsError extends SharedLinkError
-    settings_error SharedLinkSettingsError
-        "There is an error with the given settings."
-    email_not_verified
-        "This user's email address is not verified. This functionality is only
-        available on accounts with a verified email address. Users can verify
-        their email address :link:`here https://www.dropbox.com/help/317`."
-
-union_closed PendingUploadMode
-    "Flag to indicate pending upload default (for linking to not-yet-existing paths)."
-    file
-        "Assume pending uploads are files."
-    folder
-        "Assume pending uploads are folders."
-
-union RequestedLinkAccessLevel
-    viewer
-        "Users who use the link can view and comment on the content."
-    editor
-        "Users who use the link can edit, view and comment on the content.
-        Note not all file types support edit links yet."
-    max
-        "Request for the maximum access level you can set the link to."
-    default
-        "Request for the default access level the user has set."
-
-union_closed RequestedVisibility
-    "The access permission that can be requested by the caller for the shared link.
-    Note that the final resolved visibility of the shared link takes into account other aspects,
-    such as team and shared folder settings.
-    Check the :type:`ResolvedVisibility` for more info on the possible resolved visibility values
-    of shared links."
-    public
-        "Anyone who has received the link can access it. No login required."
-    team_only
-        "Only members of the same team can
-        access the link. Login is required."
-    password
-        "A link-specific password is required to access the
-        link. Login is not required."
-
-union ResolvedVisibility extends RequestedVisibility
-    "The actual access permissions values of shared links after taking into account user
-    preferences and the team and shared folder settings.
-    Check the :type:`RequestedVisibility` for more info on the possible visibility values
-    that can be set by the shared link's owner."
-    team_and_password
-        "Only members of the same team who
-        have the link-specific password can access the link. Login is required."
-    shared_folder_only
-        "Only members of the shared folder containing the linked file
-        can access the link. Login is required."
-    no_one
-        "The link merely points the user to the content, and does not grant any additional rights.
-        Existing members of the content who use this link can only access the content with their
-        pre-existing access rights. Either on the file directly, or inherited from a parent folder."
-    only_you
-        "Only the current user can view this link."
-
-union RevokeSharedLinkError extends SharedLinkError
-    shared_link_malformed
-        "Shared link is malformed."
-
-union SharedLinkAccessFailureReason
-    login_required
-        "User is not logged in."
-    email_verify_required
-        "This user's email address is not verified. This functionality is only
-        available on accounts with a verified email address. Users can verify
-        their email address :link:`here https://www.dropbox.com/help/317`."
-    password_required
-        "The link is password protected."
-    team_only
-        "Access is allowed for team members only."
-    owner_only
-        "Access is allowed for the shared link's owner only."
-
-union SharedLinkAlreadyExistsMetadata
-    metadata SharedLinkMetadata
-        "Metadata of the shared link that already exists."
-
-union SharedLinkError
-    shared_link_not_found
-        "The shared link wasn't found."
-    shared_link_access_denied
-        "The caller is not allowed to access this shared link."
-    unsupported_link_type
-        "This type of link is not supported; use :route:`files.export` instead."
-    unsupported_parameter_field
-        "Private shared links do not support `path` or `link_password` parameter fields."
-
-union SharedLinkMetadataError extends SharedLinkError
-    "The potential errors for a call to get_shared_link_metadata."
-
-union_closed SharedLinkSettingsError
-    invalid_settings
-        "The given settings are invalid
-        (for example, all attributes of the :type:`SharedLinkSettings` are empty,
-        the requested visibility is :field:`RequestedVisibility.password` but the
-        :field:`SharedLinkSettings.link_password` is missing, :field:`SharedLinkSettings.expires`
-        is set to the past, etc.)."
-    not_authorized
-        "User is not allowed to modify the settings of this link. Note that basic
-        users can only set :field:`RequestedVisibility.public`
-        as the :field:`SharedLinkSettings.requested_visibility` and cannot
-        set :field:`SharedLinkSettings.expires`."
-
-union Visibility
-    "Who can access a shared link.
-    The most open visibility is :field:`public`.
-    The default depends on many aspects, such as team and user
-    preferences and shared folder settings."
-    public
-        "Anyone who has received the link can access it. No login required."
-    team_only
-        "Only members of the same team can
-        access the link. Login is required."
-    password
-        "A link-specific password is required to access the
-        link. Login is not required."
-    team_and_password
-        "Only members of the same team who
-        have the link-specific password can access the link."
-    shared_folder_only
-        "Only members of the shared folder containing the linked file
-        can access the link. Login is required."
-
-union VisibilityPolicyDisallowedReason
-    delete_and_recreate
-        "The user needs to delete and recreate the link to change the visibility policy."
-    restricted_by_shared_folder
-        "The parent shared folder restricts sharing of links outside the shared folder. To change
-        the visibility policy, remove the restriction from the parent shared folder."
-    restricted_by_team
-        "The team policy prevents links being shared outside the team."
-    user_not_on_team
-        "The user needs to be on a team to set this policy."
-    user_account_type
-        "The user is a basic user or is on a limited team."
-    permission_denied
-        "The user does not have permission."
-
-union ChangeLinkExpirationPolicy
-    "Enumerates acceptable values for team's ChangeLinkExpirationPolicy setting."
-    allowed
-    not_allowed
-
-struct LinkMetadata
-    "Metadata for a shared link. This can be either a
-    :type:`PathLinkMetadata` or :type:`CollectionLinkMetadata`."
-    union
-        path PathLinkMetadata
-        collection CollectionLinkMetadata
-    url String
-        "URL of the shared link."
-    visibility Visibility
-        "Who can access the link."
-    expires common.DropboxTimestamp?
-        "Expiration time, if set. By default the link won't expire."
-
-    example default
-        path = default
-
-struct SharedLinkMetadata
-    "The metadata of a shared link."
-    union
-        file FileLinkMetadata
-        folder FolderLinkMetadata
-    url String
-        "URL of the shared link."
-    id Id?
-        "A unique identifier for the linked file."
-    name String
-        "The linked file name (including extension).
-        This never contains a slash."
-    expires common.DropboxTimestamp?
-        "Expiration time, if set. By default the link won't expire."
-    path_lower String?
-        "The lowercased full path in the user's Dropbox. This always starts with a slash.
-        This field will only be present only if the linked file is in the authenticated user's
-        dropbox and the user is the owner of the link."
-    link_permissions LinkPermissions
-        "The link's access permissions."
-    team_member_info TeamMemberInfo?
-        "The team membership information of the link's owner.  This field will only be present
-        if the link's owner is a team member."
-    content_owner_team_info TeamInfo?
-        "The team information of the content's owner. This field will only be present if
-        the content's owner is a team member and the content's owner team is different from the
-        link's owner team."
-
-    example default
-        file = default
-    
-    example folder_link_metadata
-        folder = default
-
-struct CollectionLinkMetadata extends LinkMetadata
-    "Metadata for a collection-based shared link."
-
-    example default
-        url = "https://www.dropbox.com/sh/s6fvw6ol7rmqo1x/AAAgWRSbjmYDvPpDB30Sykjfa?dl=0"
-        expires = null
-        visibility = public
-
-struct CreateSharedLinkArg
-    path String
-        "The path to share."
-    short_url Boolean = false
-    pending_upload PendingUploadMode?
-        "If it's okay to share a path that does not yet exist, set this to
-        either :field:`PendingUploadMode.file` or :field:`PendingUploadMode.folder`
-        to indicate whether to assume it's a file or folder."
-
-    example default
-        path = "/Homework/Math/Prime_Numbers.txt"
-
-struct CreateSharedLinkWithSettingsArg
-    path ReadPath
-        "The path to be shared by the shared link."
-    settings SharedLinkSettings?
-        "The requested settings for the newly created shared link."
-
-    example default
-        path = "/Prime_Numbers.txt"
-        settings = default
-
-struct FileLinkMetadata extends SharedLinkMetadata
-    "The metadata of a file shared link."
-    client_modified common.DropboxTimestamp
-        "The modification time set by the desktop client
-        when the file was added to Dropbox. Since this time is not verified
-        (the Dropbox server stores whatever the desktop client sends up), this
-        should only be used for display purposes (such as sorting) and not,
-        for example, to determine if a file has changed or not."
-    server_modified common.DropboxTimestamp
-        "The last time the file was modified on Dropbox."
-    rev Rev
-        "A unique identifier for the current revision of a file. This field is
-        the same rev as elsewhere in the API and can be used to detect changes
-        and avoid conflicts."
-    size UInt64
-        "The file size in bytes."
-
-    example default
-        url = "https://www.dropbox.com/s/2sn712vy1ovegw8/Prime_Numbers.txt?dl=0"
-        id = "id:a4ayc_80_OEAAAAAAAAAXw"
-        name = "Prime_Numbers.txt"
-        path_lower = "/homework/math/prime_numbers.txt"
-        link_permissions = default
-        team_member_info = default
-        client_modified = "2015-05-12T15:50:38Z"
-        server_modified = "2015-05-12T15:50:38Z"
-        rev = "a1c10ce0dd78"
-        size = 7212
-
-struct FolderLinkMetadata extends SharedLinkMetadata
-    "The metadata of a folder shared link."
-
-    example default
-        url = "https://www.dropbox.com/sh/s6fvw6ol7rmqo1x/AAAgWRSbjmYDvPpDB30Sykjfa?dl=0"
-        id = "id:a4ayc_80_OEAAAAAAAAAXw"
-        name = "Math"
-        path_lower = "/homework/math"
-        team_member_info = default
-        link_permissions = default
-
-struct GetSharedLinkMetadataArg
-    url String
-        "URL of the shared link."
-    path Path?
-        "If the shared link is to a folder, this parameter can be used to retrieve the metadata for
-        a specific file or sub-folder in this folder. A relative path should be used."
-    link_password String?
-        "If the shared link has a password, this parameter can be used."
-
-    example default
-        url = "https://www.dropbox.com/s/2sn712vy1ovegw8/Prime_Numbers.txt?dl=0"
-        path = "/Prime_Numbers.txt"
-
-struct GetSharedLinksArg
-    path String?
-        "See :route:`get_shared_links` description."
-
-    example default
-        path = ""
-    
-    example math_homework_links
-        path = "/Homework/Math"
-
-struct GetSharedLinksResult
-    links List(LinkMetadata)
-        "Shared links applicable to the path argument."
-
-    example default
-        links = [default]
-
-struct LinkAudienceOption
-    audience LinkAudience
-        "Specifies who can access the link."
-    allowed Boolean
-        "Whether the user calling this API can select this audience option."
-    disallowed_reason LinkAudienceDisallowedReason?
-        "If :field:`allowed` is :val:`false`, this will provide the reason that the user is not
-        permitted to set the visibility to this policy."
-
-    example public
-        audience = public
-        allowed = true
-    
-    example team
-        audience = team
-        allowed = false
-    
-    example no_one
-        audience = no_one
-        allowed = true
-
-struct LinkPermissions
-    resolved_visibility ResolvedVisibility?
-        "The current visibility of the link after considering the shared links policies of the
-        the team (in case the link's owner is part of a team) and the shared folder (in case the
-        linked file is part of a shared folder). This field is shown only if the caller has access
-        to this info (the link's owner always has access to this data). For some links, an
-        effective_audience value is returned instead."
-    requested_visibility RequestedVisibility?
-        "The shared link's requested visibility. This can be overridden by the team and shared
-        folder policies. The final visibility, after considering these policies, can be found in
-        :field:`resolved_visibility`. This is shown only if the caller is the link's
-        owner and resolved_visibility is returned instead of effective_audience."
-    can_revoke Boolean
-        "Whether the caller can revoke the shared link."
-    revoke_failure_reason SharedLinkAccessFailureReason?
-        "The failure reason for revoking the link. This field will only be present if the
-        :field:`can_revoke` is :val:`false`."
-    effective_audience LinkAudience?
-        "The type of audience who can benefit from the access level specified by the
-        `link_access_level` field."
-    link_access_level LinkAccessLevel?
-        "The access level that the link will grant to its users. A link can grant additional rights
-        to a user beyond their current access level. For example, if a user was invited as a viewer
-        to a file, and then opens a link with `link_access_level` set to `editor`, then they will
-        gain editor privileges. The `link_access_level` is a property of the link, and does not
-        depend on who is calling this API. In particular, `link_access_level` does not take into
-        account the API caller's current permissions to the content."
-    visibility_policies List(VisibilityPolicy)
-        "A list of policies that the user might be able to set for the visibility."
-    can_set_expiry Boolean
-        "Whether the user can set the expiry settings of the link. This refers to the ability to
-        create a new expiry and modify an existing expiry."
-    can_remove_expiry Boolean
-        "Whether the user can remove the expiry of the link."
-    allow_download Boolean
-        "Whether the link can be downloaded or not."
-    can_allow_download Boolean
-        "Whether the user can allow downloads via the link. This refers to the ability to remove a
-        no-download restriction on the link."
-    can_disallow_download Boolean
-        "Whether the user can disallow downloads via the link. This refers to the ability to impose
-        a no-download restriction on the link."
-    allow_comments Boolean
-        "Whether comments are enabled for the linked file. This takes the team commenting policy into account."
-    team_restricts_comments Boolean
-        "Whether the team has disabled commenting globally."
-    audience_options List(LinkAudienceOption)?
-        "A list of link audience options the user might be able to set as the new audience."
-    can_set_password Boolean?
-        "Whether the user can set a password for the link."
-    can_remove_password Boolean?
-        "Whether the user can remove the password of the link."
-    require_password Boolean?
-        "Whether the user is required to provide a password to view the link."
-    can_use_extended_sharing_controls Boolean?
-        "Whether the user can use extended sharing controls, based on their account type."
-    can_sync Boolean?
-        "Whether a user can save the content to their Dropbox account."
-    can_request_access Boolean?
-        "Whether the user can request access to the content."
-    enforce_shared_link_password_policy team_policies.EnforceLinkPasswordPolicy?
-        "Whether the updated externally available shared link must have password set.
-        Not provided if the link is not team owned."
-    days_to_expire_policy team_policies.DefaultLinkExpirationDaysPolicy?
-        "Existing owning team's policy for default number of days from today to link's expiration.
-        Not provided if the link is not team owned."
-    change_shared_link_expiration_policy ChangeLinkExpirationPolicy?
-        "When owning team's policy :field:`change_shared_link_expiration_policy` is :field:`ChangeLinkExpirationPolicy.not_allowed`,
-        the updated externally available shared link expiration value cannot be less strict
-        than :field:`days_to_expire_policy`.
-        In this case :field:`days_to_expire_policy` is expected to be different from `none`.
-        Not provided if the link is not team owned."
-
-    example default
-        resolved_visibility = public
-        can_revoke = false
-        revoke_failure_reason = owner_only
-        visibility_policies = [public, password]
-        can_set_expiry = false
-        can_remove_expiry = false
-        allow_download = true
-        can_allow_download = true
-        can_disallow_download = false
-        allow_comments = true
-        team_restricts_comments = true
-        audience_options = [public, team, no_one]
-        can_set_password = true
-        can_remove_password = true
-        require_password = false
-        can_use_extended_sharing_controls = false
-
-struct ListSharedLinksArg
-    path ReadPath?
-        "See :route:`list_shared_links` description."
-    cursor String?
-        "The cursor returned by your last call to :route:`list_shared_links`."
-    direct_only Boolean?
-        "See :route:`list_shared_links` description."
-
-    example default
-        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
-    
-    example path
-        path = "/Homework/Math"
-    
-    example id
-        path = "id:a4ayc_80_OEAAAAAAAAAYa"
-    
-    example rev
-        path = "rev:a1c10ce0dd78"
-    
-    example id_no_parent_links
-        path = "id:a4ayc_80_OEAAAAAAAAAYa"
-        direct_only = true
-
-struct ListSharedLinksResult
-    links List(SharedLinkMetadata)
-        "Shared links applicable to the path argument."
-    has_more Boolean
-        "Is true if there are additional shared links that have not been returned
-        yet. Pass the cursor into :route:`list_shared_links` to retrieve them."
-    cursor String?
-        "Pass the cursor into :route:`list_shared_links` to obtain the additional links. Cursor is
-        returned only if no path is given."
-
-    example default
-        links = [default]
-        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
-        has_more = true
-
-struct ModifySharedLinkSettingsArgs
-    url String
-        "URL of the shared link to change its settings."
-    settings SharedLinkSettings
-        "Set of settings for the shared link."
-    remove_expiration Boolean = false
-        "If set to true, removes the expiration of the shared link."
-
-    example default
-        url = "https://www.dropbox.com/s/2sn712vy1ovegw8/Prime_Numbers.txt?dl=0"
-        settings = default
-
-struct PathLinkMetadata extends LinkMetadata
-    "Metadata for a path-based shared link."
-    path String
-        "Path in user's Dropbox."
-
-    example default
-        url = "https://www.dropbox.com/s/2sn712vy1ovegw8/Prime_Numbers.txt?dl=0"
-        path = "/Homework/Math/Prime_Numbers.txt"
-        expires = null
-        visibility = public
-
-struct RevokeSharedLinkArg
-    url String
-        "URL of the shared link."
-
-    example default
-        url = "https://www.dropbox.com/s/2sn712vy1ovegw8/Prime_Numbers.txt?dl=0"
-
-struct SharedLinkSettings
-    require_password Boolean?
-        "Boolean flag to enable or disable password protection."
-    link_password String?
-        "If :field:`require_password` is true, this is needed
-        to specify the password to access the link."
-    expires common.DropboxTimestamp?
-        "Expiration time of the shared link. By default the link won't expire."
-    audience LinkAudience?
-        "The new audience who can benefit from the access level specified by the link's access level
-        specified in the `link_access_level` field of `LinkPermissions`. This is used in conjunction
-        with team policies and shared folder policies to determine the final effective audience type
-        in the `effective_audience` field of `LinkPermissions."
-    access RequestedLinkAccessLevel?
-        "Requested access level you want the audience to gain from this link. Note, modifying access
-        level for an existing link is not supported."
-    requested_visibility RequestedVisibility?
-        "Use :field:`audience` instead.  The requested access for this shared link."
-    allow_download Boolean?
-        "Boolean flag to allow or not download capabilities for shared links."
-
-    example default
-        requested_visibility = public
-        audience = public
-        access = viewer
-        allow_download = true
-
-struct TeamMemberInfo
-    "Information about a team member."
-    team_info TeamInfo
-        "Information about the member's team."
-    display_name String
-        "The display name of the user."
-    member_id String?
-        "ID of user as a member of a team. This field will only be present if the member is in the
-        same team as current user."
-
-    example default
-        team_info = default
-        display_name = "Roger Rabbit"
-        member_id = "dbmid:abcd1234"
-
-struct VisibilityPolicy
-    policy RequestedVisibility
-        "This is the value to submit when saving the visibility setting."
-    resolved_policy AlphaResolvedVisibility
-        "This is what the effective policy would be, if you selected this option. The resolved
-        policy is obtained after considering external effects such as shared folder settings and
-        team policy. This value is guaranteed to be provided."
-    allowed Boolean
-        "Whether the user is permitted to set the visibility to this policy."
-    disallowed_reason VisibilityPolicyDisallowedReason?
-        "If :field:`allowed` is :val:`false`, this will provide the reason that the user is not
-        permitted to set the visibility to this policy."
-
-    example public
-        policy = public
-        resolved_policy = public
-        allowed = true
-    
-    example public_team
-        policy = public
-        resolved_policy = team_only
-        allowed = false
-        disallowed_reason = restricted_by_team
-    
-    example public_shared_folder
-        policy = public
-        resolved_policy = shared_folder_only
-        allowed = false
-        disallowed_reason = restricted_by_shared_folder
-    
-    example password
-        policy = password
-        resolved_policy = password
-        allowed = true
-    
-    example password_team
-        policy = password
-        resolved_policy = team_and_password
-        allowed = true
-    
-    example password_shared_folder
-        policy = password
-        resolved_policy = shared_folder_only
-        allowed = false
-        disallowed_reason = restricted_by_shared_folder
-    
-    example team_only
-        policy = team_only
-        resolved_policy = team_only
-        allowed = true
-    
-    example team_shared_folder
-        policy = team_only
-        resolved_policy = shared_folder_only
-        allowed = false
-        disallowed_reason = restricted_by_shared_folder
-
-
-union LinkExpiry
-    remove_expiry
-        "Remove the currently set expiry for the link."
-    set_expiry common.DropboxTimestamp
-        "Set a new expiry or change an existing expiry."
-
-union LinkPassword
-    remove_password
-        "Remove the currently set password for the link."
-    set_password String
-        "Set a new password or change an existing password."
-
-union LinkAudience
-    public
-        "Link is accessible by anyone."
-    team
-        "Link is accessible only by team members."
-    no_one
-        "The link can be used by no one. The link merely points the user to the content, and does
-        not grant additional rights to the user. Members of the content who use this link can only
-        access the content with their pre-existing access rights."
-    password
-        "Use `require_password` instead. A link-specific password is required to access the
-        link. Login is not required."
-    members
-        "Link is accessible only by members of the content."
-
-union LinkAction
-    "Actions that can be performed on a link."
-    change_access_level
-        "Change the access level of the link."
-    change_audience
-        "Change the audience of the link."
-    remove_expiry
-        "Remove the expiry date of the link."
-    remove_password
-        "Remove the password of the link."
-    set_expiry
-        "Create or modify the expiry date of the link."
-    set_password
-        "Create or modify the password of the link."
-
-struct LinkSettings
-    "Settings that apply to a link."
-    access_level AccessLevel?
-        "The access level on the link for this file. Currently,
-        it only accepts 'viewer' and 'viewer_no_comment'."
-    audience LinkAudience?
-        "The type of audience on the link for this file."
-    expiry LinkExpiry?
-        "An expiry timestamp to set on a link."
-    password LinkPassword?
-        "The password for the link."
-
-struct LinkPermission
-    "Permissions for actions that can be performed on a link."
-    action LinkAction
-    allow Boolean
-    reason PermissionDeniedReason?
-
-    example default
-        action = change_audience
-        allow = true
-
-struct SharedContentLinkMetadataBase
-    access_level AccessLevel?
-        "The access level on the link for this file."
-    audience_options List(LinkAudience)
-        "The audience options that are available for the content. Some audience options may be
-        unavailable. For example, team_only may be unavailable if the content is not owned by a
-        user on a team. The 'default' audience option is always available if the user can modify
-        link settings."
-    audience_restricting_shared_folder AudienceRestrictingSharedFolder?
-        "The shared folder that prevents the link audience for this link from being more
-        restrictive."
-    current_audience LinkAudience
-        "The current audience of the link."
-    expiry common.DropboxTimestamp?
-        "Whether the link has an expiry set on it. A link with an expiry will have its
-        audience changed to members when the expiry is reached."
-    link_permissions List(LinkPermission)
-        "A list of permissions for actions you can perform on the link."
-    password_protected Boolean
-        "Whether the link is protected by a password."
-
-struct SharedContentLinkMetadata extends SharedContentLinkMetadataBase
-    "Metadata of a shared link for a file or folder."
-    audience_exceptions AudienceExceptions?
-        "The content inside this folder with link audience different than this folder's. This is
-        only returned when an endpoint that returns metadata for a single shared folder is called,
-        e.g. /get_folder_metadata."
-    url String
-        "The URL of the link."
-
-    example default
-        audience_options = [public, team, members]
-        current_audience = public
-        link_permissions = [default]
-        password_protected = false
-        url = ""
-
-struct ExpectedSharedContentLinkMetadata extends SharedContentLinkMetadataBase
-    "The expected metadata of a shared link for a file or folder when a link is first created for
-    the content. Absent if the link already exists."
-
-    example default
-        audience_options = [public, team, members]
-        current_audience = public
-        link_permissions = [default]
-        password_protected = false
-
-struct AudienceRestrictingSharedFolder
-    "Information about the shared folder that prevents the link audience for this link from being
-    more restrictive."
-    shared_folder_id common.SharedFolderId
-        "The ID of the shared folder."
-    name String
-        "The name of the shared folder."
-    audience LinkAudience
-        "The link audience of the shared folder."
-
-struct AudienceExceptions
-    "The total count and truncated list of information of content inside this folder that has a
-    different audience than the link on this folder. This is only returned for folders."
-    count UInt32
-    exceptions List(AudienceExceptionContentInfo)
-        "A truncated list of some of the content that is an exception. The length of this list could
-        be smaller than the count since it is only a sample but will not be empty as long as
-        count is not 0."
-
-    example default
-        count = 0
-        exceptions = []
-
-struct AudienceExceptionContentInfo
-    "Information about the content that has a link audience different than that of this folder."
-    name String
-        "The name of the content, which is either a file or a folder."
-
-    example default
-        name = "sample file name"
-
-
-route get_shared_link_file (GetSharedLinkFileArg, SharedLinkMetadata, GetSharedLinkFileError)
-    "Download the shared link's file from a user's Dropbox.
-    This is a download-style endpoint that returns the file content."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "app, user"
-        host = "content"
-        scope = "sharing.read"
-        style = "download"
-
-
-union AccessLevel
-    "Defines the access levels for collaborators."
-    owner
-        "The collaborator is the owner of the shared folder. Owners can
-        view and edit the shared folder as well as set the folder's
-        policies using :route:`update_folder_policy`."
-    editor
-        "The collaborator can both view and edit the shared folder."
-    viewer
-        "The collaborator can only view the shared folder."
-    viewer_no_comment
-        "The collaborator can only view the shared folder and does
-        not have any access to comments."
-    traverse
-        "The collaborator can only view the shared folder that they have
-        access to."
-    no_access
-        "If there is a Righteous Link on the folder which grants access
-        and the user has visited such link, they are allowed to perform
-        certain action (i.e. add themselves to the folder) via the link
-        access even though the user themselves are not a member on the
-        shared folder yet."
-
-struct InsufficientPlan
-    message String
-        "A message to tell the user to upgrade in order to support expected action."
-    upsell_url String?
-        "A URL to send the user to in order to obtain the account type they need, e.g. upgrading.
-        Absent if there is no action the user can take to upgrade."
-
-union PermissionDeniedReason
-    "Possible reasons the user is denied a permission."
-    user_not_same_team_as_owner
-        "User is not on the same team as the folder owner."
-    user_not_allowed_by_owner
-        "User is prohibited by the owner from taking the action."
-    target_is_indirect_member
-        "Target is indirectly a member of the folder, for example by being part of a group."
-    target_is_owner
-        "Target is the owner of the folder."
-    target_is_self
-        "Target is the user itself."
-    target_not_active
-        "Target is not an active member of the team."
-    folder_is_limited_team_folder
-        "Folder is team folder for a limited team."
-    owner_not_on_team
-        "The content owner needs to be on a Dropbox team to perform this action."
-    permission_denied
-        "The user does not have permission to perform this action on the link."
-    restricted_by_team
-        "The user's team policy prevents performing this action on the link."
-    user_account_type
-        "The user's account type does not support this action."
-    user_not_on_team
-        "The user needs to be on a Dropbox team to perform this action."
-    folder_is_inside_shared_folder
-        "Folder is inside of another shared folder."
-    restricted_by_parent_folder
-        "Policy cannot be changed due to restrictions from parent folder."
-    insufficient_plan InsufficientPlan
-
-
-route create_shared_link_with_settings (CreateSharedLinkWithSettingsArg, SharedLinkMetadata, CreateSharedLinkWithSettingsError)
-    "Create a shared link with custom settings.
-    If no settings are given then the default visibility is RequestedVisibility.public
-    (The resolved visibility, though, may depend on other aspects such as team and shared folder
-    settings)."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "sharing.write"
-        select_admin_mode = "team_admin"
-
-route get_shared_link_metadata (GetSharedLinkMetadataArg, SharedLinkMetadata, SharedLinkMetadataError)
-    "Get the shared link's metadata."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "app, user"
-        scope = "sharing.read"
-
-route modify_shared_link_settings (ModifySharedLinkSettingsArgs, SharedLinkMetadata, ModifySharedLinkSettingsError)
-    "Modify the shared link's settings.
-    If the requested visibility conflict with the shared links policy of the team or the
-    shared folder (in case the linked file is part of a shared folder) then the
-    LinkPermissions.resolved_visibility of the returned SharedLinkMetadata will
-    reflect the actual visibility of the shared link and the
-    LinkPermissions.requested_visibility will reflect the requested visibility."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "sharing.write"
-
-
-route get_file_metadata (GetFileMetadataArg, SharedFileMetadata, GetFileMetadataError)
-    "Returns shared file metadata."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-        select_admin_mode = "team_admin"
-
-
-route get_folder_metadata (GetMetadataArgs, SharedFolderMetadata, SharedFolderAccessError)
-    "Returns shared folder metadata by its folder ID."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-        select_admin_mode = "whole_team"
-
-route list_folder_members (ListFolderMembersArgs, SharedFolderMembers, SharedFolderAccessError)
-    "Returns shared folder membership by its folder ID."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-        select_admin_mode = "whole_team"
-
-route list_mountable_folders (ListFoldersArgs, ListFoldersResult, Void)
-    "Return the list of all shared folders the current user can mount or unmount."
-
-    attrs
-        auth = "user"
-        scope = "sharing.read"
-
-
 route add_folder_member (AddFolderMemberArg, Void, AddFolderMemberError)
     "Allows an owner or editor (if the ACL update policy allows) of a shared
     folder to add another member.
@@ -2852,4 +2877,28 @@ route update_folder_policy (UpdateFolderPolicyArg, SharedFolderMetadata, UpdateF
         auth = "user"
         scope = "sharing.write"
         select_admin_mode = "team_admin"
+
+
+route get_folder_metadata (GetMetadataArgs, SharedFolderMetadata, SharedFolderAccessError)
+    "Returns shared folder metadata by its folder ID."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
+        select_admin_mode = "whole_team"
+
+route list_folder_members (ListFolderMembersArgs, SharedFolderMembers, SharedFolderAccessError)
+    "Returns shared folder membership by its folder ID."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
+        select_admin_mode = "whole_team"
+
+route list_mountable_folders (ListFoldersArgs, ListFoldersResult, Void)
+    "Return the list of all shared folders the current user can mount or unmount."
+
+    attrs
+        auth = "user"
+        scope = "sharing.read"
 

--- a/team.stone
+++ b/team.stone
@@ -11,1508 +11,108 @@ import team_policies
 import users
 import users_common
 
-union NamespaceType
-    app_folder
-        "App sandbox folder."
-    shared_folder
-        "Shared folder."
-    team_folder
-        "Top-level team-owned folder."
-    team_member_folder
-        "Team member's home folder."
-    team_member_root
-        "Team member's root folder."
+union_closed TeamMembershipType
+    full
+        "User uses a license and has full access to team resources like the shared quota."
+    limited
+        @common.Deprecated
+        "User does not have access to the shared quota and team admins have restricted administrative control."
 
-union TeamNamespacesListContinueError extends TeamNamespacesListError
-    invalid_cursor
-        "The cursor is invalid."
+struct RemovedStatus
+    is_recoverable Boolean
+        "True if the removed team member is recoverable."
+    is_disconnected Boolean
+        "True if the team member's account was converted to individual account."
 
-union TeamNamespacesListError
-    invalid_arg
-        "Argument passed in is invalid."
+    example default
+        is_recoverable = false
+        is_disconnected = false
 
-struct NamespaceMetadata
-    "Properties of a namespace."
-    name String
-        "The name of this namespace."
-    namespace_id common.SharedFolderId
-        "The ID of this namespace."
-    namespace_type NamespaceType
-        "The type of this namespace."
-    team_member_id team_common.TeamMemberId?
-        "If this is a team member or app folder, the ID of the owning team member.
-        Otherwise, this field is not present."
+union_closed TeamMemberStatus
+    "The user's status as a member of a specific team."
+    active
+        "User has successfully joined the team."
+    invited
+        "User has been invited to a team, but has not joined the team yet."
+    suspended
+        "User is no longer a member of the team, but the account can be un-suspended,
+        re-establishing the user as a team member."
+    removed RemovedStatus
+        "User is no longer a member of the team.
+        Removed users are only listed when include_removed is true in members/list."
 
-    example shared_folder
-        name = "Marketing"
-        namespace_id = "123456789"
-        namespace_type = shared_folder
-    
-    example team_member_folder
-        name = "Franz Ferdinand"
-        namespace_id = "123456789"
-        namespace_type = team_member_folder
+struct MemberProfile
+    "Basic member profile."
+    team_member_id team_common.TeamMemberId
+        "ID of user as a member of a team."
+    external_id String?
+        "External ID that a team can attach to the user.
+        An application using the API may find it easier to use their
+        own IDs instead of Dropbox IDs like account_id or team_member_id."
+    account_id users_common.AccountId?
+        "A user's account identifier."
+    email String
+        "Email address of user."
+    email_verified Boolean
+        "Is true if the user's email is verified to be owned by the user."
+    secondary_emails List(secondary_emails.SecondaryEmail)?
+        "Secondary emails of a user."
+    status TeamMemberStatus
+        "The user's status as a member of a specific team."
+    name users.Name
+        "Representations for a person's name."
+    membership_type TeamMembershipType
+        "The user's membership type: full (normal team member) vs limited (does not use a license; no access to the team's shared quota)."
+    invited_on common.DropboxTimestamp?
+        "The date and time the user was invited to the team (contains value only when the member's status matches :field:`TeamMemberStatus.invited`)."
+    joined_on common.DropboxTimestamp?
+        "The date and time the user joined as a member of a specific team."
+    suspended_on common.DropboxTimestamp?
+        "The date and time the user was suspended from the team (contains value only when the member's status matches :field:`TeamMemberStatus.suspended`)."
+    persistent_id String?
+        "Persistent ID that a team can attach to the user.
+        The persistent ID is unique ID to be used for SAML authentication."
+    is_directory_restricted Boolean?
+        "Whether the user is a directory restricted user."
+    profile_photo_url String?
+        "URL for the photo representing the user, if one is set."
+
+    example default
         team_member_id = "dbmid:1234567"
-
-struct TeamNamespacesListResult
-    "Result for :route:`namespaces/list`."
-    namespaces List(NamespaceMetadata)
-        "List of all namespaces the team can access."
-    cursor String
-        "Pass the cursor into :route:`namespaces/list/continue` to obtain
-        additional namespaces. Note that duplicate namespaces may be returned."
-    has_more Boolean
-        "Is true if there are additional namespaces that have not been returned yet."
-
-    example default
-        namespaces = [shared_folder, team_member_folder]
-        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
-        has_more = false
-
-struct TeamNamespacesListArg
-    limit UInt32(max_value=1000, min_value=1) = 1000
-        "Specifying a value here has no effect."
-
-    example default
-        limit = 1
-    
-    example with_filter
-        limit = 1
-
-struct TeamNamespacesListContinueArg
-    cursor String
-        "Indicates from what point to get the next set of team-accessible namespaces."
-
-    example default
-        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
-    
-    example with_filter
-        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
-
-route namespaces/list (TeamNamespacesListArg, TeamNamespacesListResult, TeamNamespacesListError)
-    "Returns a list of all team-accessible namespaces. This list includes team folders,
-    shared folders containing team members, team members' home namespaces, and team members'
-    app folders. Home namespaces and app folders are always owned by this team or members of the
-    team, but shared folders may be owned by other users or other teams. Duplicates may occur in the
-    list."
-
-    attrs
-        auth = "team"
-        scope = "team_data.member"
-
-route namespaces/list/continue (TeamNamespacesListContinueArg, TeamNamespacesListResult, TeamNamespacesListContinueError)
-    "Once a cursor has been retrieved from :route:`namespaces/list`, use this to paginate
-    through all team-accessible namespaces. Duplicates may occur in the list."
-
-    attrs
-        auth = "team"
-        scope = "team_data.member"
-
-
-alias GroupsGetInfoResult = List(GroupsGetInfoItem)
-
-union_closed GroupAccessType
-    "Role of a user in group."
-    member
-        "User is a member of the group, but has no special permissions."
-    owner
-        "User can rename the group, and add/remove members."
-
-    example default
-        member = null
-
-union_closed GroupSelector
-    "Argument for selecting a single group, either by group_id or by external group ID."
-    group_id team_common.GroupId
-        "Group ID."
-    group_external_id team_common.GroupExternalId
-        "External ID of the group."
-
-    example default
-        group_id = "g:e2db7665347abcd600000000001a2b3c"
-
-union GroupSelectorError
-    "Error that can be raised when :type:`GroupSelector` is used."
-    group_not_found
-        "No matching group found. No groups match the specified group ID."
-
-union GroupSelectorWithTeamGroupError extends GroupSelectorError
-    "Error that can be raised when :type:`GroupSelector` is used and team groups are disallowed from
-    being used."
-    system_managed_group_disallowed
-        "This operation is not supported on system-managed groups."
-
-union_closed GroupsSelector
-    "Argument for selecting a list of groups, either by group_ids, or external group IDs."
-    group_ids List(team_common.GroupId)
-        "List of group IDs."
-    group_external_ids List(String)
-        "List of external IDs of groups."
-
-    example default
-        group_ids = ["g:e2db7665347abcd600000000001a2b3c", "g:111111147abcd6000000000222222c"]
-
-union GroupMemberSelectorError extends GroupSelectorWithTeamGroupError
-    "Error that can be raised when :type:`GroupMemberSelector` is used, and the user
-    is required to be a member of the specified group."
-    member_not_in_group
-        "The specified user is not a member of this group."
-
-union GroupMembersSelectorError extends GroupSelectorWithTeamGroupError
-    "Error that can be raised when :type:`GroupMembersSelector` is used, and the users
-    are required to be members of the specified group."
-    member_not_in_group
-        "At least one of the specified users is not a member of the group."
-
-union GroupsListContinueError
-    invalid_cursor
-        "The cursor is invalid."
-
-union_closed GroupsGetInfoItem
-    id_not_found String = ""
-        "An ID that was provided as a parameter to :route:`groups/get_info`, and
-        did not match a corresponding group. The ID can be a group ID, or an external ID,
-        depending on how the method was called."
-    group_info GroupFullInfo
-        "Info about a group."
-
-    example default
-        group_info = default
-
-union GroupsGetInfoError
-    group_not_on_team
-        "The group is not on your team."
-
-union GroupCreateError
-    group_name_already_used
-        "The requested group name is already being used by another group."
-    group_name_invalid
-        "Group name is empty or has invalid characters."
-    external_id_already_in_use
-        "The requested external ID is already being used by another group."
-    system_managed_group_disallowed
-        "System-managed group cannot be manually created."
-
-union GroupDeleteError extends GroupSelectorWithTeamGroupError
-    group_already_deleted
-        "This group has already been deleted."
-
-union GroupUpdateError extends GroupSelectorWithTeamGroupError
-    group_name_already_used
-        "The requested group name is already being used by another group."
-    group_name_invalid
-        "Group name is empty or has invalid characters."
-    external_id_already_in_use
-        "The requested external ID is already being used by another group."
-
-union GroupMembersAddError extends GroupSelectorWithTeamGroupError
-    duplicate_user
-        "You cannot add duplicate users. One or more of the members
-        you are trying to add is already a member of the group."
-    group_not_in_team
-        "Group is not in this team. You cannot add members to a
-        group that is outside of your team."
-    members_not_in_team List(String)
-        "These members are not part of your team. Currently, you cannot add members
-        to a group if they are not part of your team, though this
-        may change in a subsequent version. To add new members to your Dropbox
-        Business team, use the :route:`members/add` endpoint."
-    users_not_found List(String)
-        "These users were not found in Dropbox."
-    user_must_be_active_to_be_owner
-        "A suspended user cannot be added to a group as :field:`GroupAccessType.owner`."
-    user_cannot_be_manager_of_company_managed_group List(String)
-        "A company-managed group cannot be managed by a user."
-
-union GroupMembersRemoveError extends GroupMembersSelectorError
-    group_not_in_team
-        "Group is not in this team. You cannot remove members from a group
-        that is outside of your team."
-    members_not_in_team List(String)
-        "These members are not part of your team."
-    users_not_found List(String)
-        "These users were not found in Dropbox."
-
-union GroupMemberSetAccessTypeError extends GroupMemberSelectorError
-    user_cannot_be_manager_of_company_managed_group
-        "A company managed group cannot be managed by a user."
-
-union GroupsMembersListContinueError
-    invalid_cursor
-        "The cursor is invalid."
-
-union GroupsPollError extends async.PollError
-    access_denied
-        "You are not allowed to poll this job."
-
-struct GroupMemberSelector
-    "Argument for selecting a group and a single user."
-    group GroupSelector
-        "Specify a group."
-    user UserSelectorArg
-        "Identity of a user that is a member of :field:`group`."
-
-    example default
-        group = default
-        user = default
-
-struct GroupMembersSelector
-    "Argument for selecting a group and a list of users."
-    group GroupSelector
-        "Specify a group."
-    users UsersSelectorArg
-        "A list of users that are members of :field:`group`."
-
-struct IncludeMembersArg
-    return_members Boolean = true
-        "Whether to return the list of members in the group.
-        Note that the default value will cause all the group members
-        to be returned in the response. This may take a long time for large groups."
-
-struct GroupMemberInfo
-    "Profile of group member, and role in group."
-    profile MemberProfile
-        "Profile of group member."
-    access_type GroupAccessType
-        "The role that the user has in the group."
-
-    example default
-        profile = default
-        access_type = default
-
-struct GroupFullInfo extends team_common.GroupSummary
-    "Full description of a group."
-    members List(GroupMemberInfo)?
-        "List of group members."
-    created UInt64
-        "The group creation time as a UTC timestamp in milliseconds since the Unix epoch."
-
-    example default
-        group_name = "project launch"
-        group_id = "g:e2db7665347abcd600000000001a2b3c"
-        member_count = 5
-        group_management_type = user_managed
-        members = [default]
-        created = 1447255518000
-
-struct GroupsListArg
-    limit UInt32(max_value=1000, min_value=1) = 1000
-        "Number of results to return per call."
-
-    example default
-        limit = 100
-
-struct GroupsListResult
-    groups List(team_common.GroupSummary)
-    cursor String
-        "Pass the cursor into :route:`groups/list/continue` to obtain the additional groups."
-    has_more Boolean
-        "Is true if there are additional groups that have not been returned
-        yet. An additional call to :route:`groups/list/continue` can retrieve them."
-
-    example default
-        groups = [default]
-        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
-        has_more = false
-
-struct GroupsListContinueArg
-    cursor String
-        "Indicates from what point to get the next set of groups."
-
-    example default
-        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
-
-struct GroupCreateArg
-    group_name String
-        "Group name."
-    add_creator_as_owner Boolean = false
-        "Automatically add the creator of the group."
-    group_external_id team_common.GroupExternalId?
-        "The creator of a team can associate an arbitrary external ID to the group."
-    group_management_type team_common.GroupManagementType?
-        "Whether the team can be managed by selected users, or only by team admins."
-
-    example default
-        group_name = "Europe sales"
-        group_external_id = "group-134"
-
-struct GroupUpdateArgs extends IncludeMembersArg
-    group GroupSelector
-        "Specify a group."
-    new_group_name String?
-        "Optional argument. Set group name to this if provided."
-    new_group_external_id team_common.GroupExternalId?
-        "Optional argument. New group external ID.
-        If the argument is None, the group's external_id won't be updated.
-        If the argument is empty string, the group's external id will be cleared."
-    new_group_management_type team_common.GroupManagementType?
-        "Set new group management type, if provided."
-
-    example default
-        group = default
-        new_group_name = "Europe west sales"
-        new_group_external_id = "sales-234"
-        new_group_management_type = company_managed
-
-struct GroupMembersChangeResult
-    "Result returned by :route:`groups/members/add` and :route:`groups/members/remove`."
-    group_info GroupFullInfo
-        "The group info after member change operation has been performed."
-    async_job_id async.AsyncJobId
-        "For legacy purposes async_job_id will always return one space ' '. Formerly, it was an ID that was used to obtain the status of granting/revoking group-owned resources. It's no longer necessary because the async processing now happens automatically."
-
-    example default
-        group_info = default
-        async_job_id = "99988877733388"
-
-struct MemberAccess
-    "Specify access type a member should have when joined to a group."
-    user UserSelectorArg
-        "Identity of a user."
-    access_type GroupAccessType
-        "Access type."
-
-    example default
-        user = default
-        access_type = default
-
-struct GroupMembersAddArg extends IncludeMembersArg
-    group GroupSelector
-        "Group to which users will be added."
-    members List(MemberAccess)
-        "List of users to be added to the group."
-
-    example default
-        group = default
-        members = [default]
-
-struct GroupMembersRemoveArg extends IncludeMembersArg
-    group GroupSelector
-        "Group from which users will be removed."
-    users List(UserSelectorArg)
-        "List of users to be removed from the group."
-
-    example default
-        group = default
-        users = [default]
-
-struct GroupMembersSetAccessTypeArg extends GroupMemberSelector
-    access_type GroupAccessType
-        "New group access type the user will have."
-    return_members Boolean = true
-        "Whether to return the list of members in the group.
-        Note that the default value will cause all the group members
-        to be returned in the response. This may take a long time for large groups."
-
-    example default
-        group = default
-        user = default
-        access_type = default
-
-struct GroupsMembersListArg
-    group GroupSelector
-        "The group whose members are to be listed."
-    limit UInt32(max_value=1000, min_value=1) = 1000
-        "Number of results to return per call."
-
-    example default
-        group = default
-        limit = 100
-
-struct GroupsMembersListResult
-    members List(GroupMemberInfo)
-    cursor String
-        "Pass the cursor into :route:`groups/members/list/continue` to obtain additional group members."
-    has_more Boolean
-        "Is true if there are additional group members that have not been returned
-        yet. An additional call to :route:`groups/members/list/continue` can retrieve them."
-
-    example default
-        members = []
-        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
-        has_more = false
-
-struct GroupsMembersListContinueArg
-    cursor String
-        "Indicates from what point to get the next set of groups."
-
-    example default
-        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
-
-route groups/list (GroupsListArg, GroupsListResult, Void)
-    "Lists groups on a team.
-    Permission : Team Information."
-
-    attrs
-        auth = "team"
-        scope = "groups.read"
-
-route groups/list/continue (GroupsListContinueArg, GroupsListResult, GroupsListContinueError)
-    "Once a cursor has been retrieved from :route:`groups/list`, use this to paginate
-    through all groups.
-    Permission : Team Information."
-
-    attrs
-        auth = "team"
-        scope = "groups.read"
-
-route groups/get_info (GroupsSelector, GroupsGetInfoResult, GroupsGetInfoError)
-    "Retrieves information about one or more groups. Note that the optional field
-    :field:`GroupFullInfo.members` is not returned for system-managed groups.
-    Permission : Team Information."
-
-    attrs
-        auth = "team"
-        scope = "groups.read"
-
-route groups/create (GroupCreateArg, GroupFullInfo, GroupCreateError)
-    "Creates a new, empty group, with a requested name.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "groups.write"
-
-route groups/delete (GroupSelector, async.LaunchEmptyResult, GroupDeleteError)
-    "Deletes a group.
-    The group is deleted immediately. However the revoking of group-owned resources
-    may take additional time.
-    Use the :route:`groups/job_status/get` to determine whether this process has completed.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "groups.write"
-
-route groups/update (GroupUpdateArgs, GroupFullInfo, GroupUpdateError)
-    "Updates a group's name and/or external ID.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "groups.write"
-
-route groups/members/add (GroupMembersAddArg, GroupMembersChangeResult, GroupMembersAddError)
-    "Adds members to a group.
-    The members are added immediately. However the granting of group-owned resources
-    may take additional time.
-    Use the :route:`groups/job_status/get` to determine whether this process has completed.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "groups.write"
-
-route groups/members/remove (GroupMembersRemoveArg, GroupMembersChangeResult, GroupMembersRemoveError)
-    "Removes members from a group.
-    The members are removed immediately. However the revoking of group-owned resources
-    may take additional time.
-    Use the :route:`groups/job_status/get` to determine whether this process has completed.
-    This method permits removing the only owner of a group, even in cases where this is not
-    possible via the web client.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "groups.write"
-
-route groups/members/set_access_type (GroupMembersSetAccessTypeArg, GroupsGetInfoResult, GroupMemberSetAccessTypeError)
-    "Sets a member's access type in a group.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "groups.write"
-
-route groups/members/list (GroupsMembersListArg, GroupsMembersListResult, GroupSelectorError)
-    "Lists members of a group.
-    Permission : Team Information."
-
-    attrs
-        auth = "team"
-        scope = "groups.read"
-
-route groups/members/list/continue (GroupsMembersListContinueArg, GroupsMembersListResult, GroupsMembersListContinueError)
-    "Once a cursor has been retrieved from :route:`groups/members/list`, use this to paginate
-    through all members of the group.
-    Permission : Team information."
-
-    attrs
-        auth = "team"
-        scope = "groups.read"
-
-route groups/job_status/get (async.PollArg, async.PollEmptyResult, GroupsPollError)
-    "Once an async_job_id is returned from :route:`groups/delete`,
-    :route:`groups/members/add` , or :route:`groups/members/remove`
-    use this method to poll the status of granting/revoking
-    group members' access to group-owned resources.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "groups.write"
-
-
-union ListMemberAppsError
-    "Error returned by :route:`linked_apps/list_member_linked_apps`."
-    member_not_found
-        "Member not found."
-
-union ListMembersAppsError
-    "Error returned by :route:`linked_apps/list_members_linked_apps`."
-    reset
-        "Indicates that the cursor has been invalidated. Call
-        :route:`linked_apps/list_members_linked_apps` again with an empty cursor to obtain a new cursor."
-
-union RevokeLinkedAppError
-    "Error returned by :route:`linked_apps/revoke_linked_app`."
-    app_not_found
-        "Application not found."
-    member_not_found
-        "Member not found."
-    app_folder_removal_not_supported
-        "App folder removal is not supported."
-
-union RevokeLinkedAppBatchError
-    "Error returned by :route:`linked_apps/revoke_linked_app_batch`."
-
-union ListTeamAppsError
-    "Error returned by :route:`linked_apps/list_team_linked_apps`."
-    reset
-        "Indicates that the cursor has been invalidated. Call
-        :route:`linked_apps/list_team_linked_apps` again with an empty cursor to obtain a new cursor."
-
-struct ListMemberAppsArg
-    team_member_id String
-        "The team member id."
-
-    example default
-        team_member_id = "dbmid:AAFdgehTzw7WlXhZJsbGCLePe8RvQGYDr-I"
-
-struct ApiApp
-    "Information on linked third party applications."
-    app_id String
-        "The application unique id."
-    app_name String
-        "The application name."
-    publisher String?
-        "The application publisher name."
-    publisher_url String?
-        "The publisher's URL."
-    linked common.DropboxTimestamp?
-        "The time this application was linked."
-    is_app_folder Boolean
-        "Whether the linked application uses a dedicated folder."
-
-    example default
-        app_id = "dbaid:AAFdgehTzw7WlXhZJsbGCLePe8RvQGYDr-I"
-        app_name = "Notes"
-        publisher = "Notes company"
-        publisher_url = "http://company.com"
-        linked = "2015-05-12T15:50:38Z"
-        is_app_folder = true
-
-struct ListMemberAppsResult
-    linked_api_apps List(ApiApp)
-        "List of third party applications linked by this team member."
-
-    example default
-        linked_api_apps = [default]
-
-struct ListMembersAppsArg
-    "Arguments for :route:`linked_apps/list_members_linked_apps`."
-    cursor String?
-        "At the first call to the :route:`linked_apps/list_members_linked_apps` the cursor shouldn't be
-        passed. Then, if the result of the call includes a cursor, the following requests should
-        include the received cursors in order to receive the next sub list of the team applications."
-
-    example default
-        cursor = "AADAQO8ZWKvBkSMXb1J9dAYVvwZ0wcvfyzIBo2e1H-_N-67pfrYKTb4oN_3LG9_ilWjblZXuiR8ubjjiQQkHq-MvDjbe_6bkcJgjnTpowrRaQA"
-
-struct MemberLinkedApps
-    "Information on linked applications of a team member."
-    team_member_id String
-        "The member unique Id."
-    linked_api_apps List(ApiApp)
-        "List of third party applications linked by this team member."
-
-    example default
-        team_member_id = "dbmid:AAFdgehTzw7WlXhZJsbGCLePe8RvQGYDr-I"
-        linked_api_apps = [default]
-
-struct ListMembersAppsResult
-    "Information returned by :route:`linked_apps/list_members_linked_apps`."
-    apps List(MemberLinkedApps)
-        "The linked applications of each member of the team."
-    has_more Boolean
-        "If true, then there are more apps available. Pass the
-        cursor to :route:`linked_apps/list_members_linked_apps` to retrieve the rest."
-    cursor String?
-        "Pass the cursor into :route:`linked_apps/list_members_linked_apps` to receive the next
-        sub list of team's applications."
-
-    example default
-        apps = [default]
-        has_more = true
-        cursor = "AADAQO8ZWKvBkSMXb1J9dAYVvwZ0wcvfyzIBo2e1H-_N-67pfrYKTb4oN_3LG9_ilWjblZXuiR8ubjjiQQkHq-MvDjbe_6bkcJgjnTpowrRaQA"
-
-struct RevokeLinkedApiAppArg
-    app_id String
-        "The application's unique id."
-    team_member_id String
-        "The unique id of the member owning the device."
-    keep_app_folder Boolean = true
-        "This flag is not longer supported, the application dedicated folder (in case the application uses
-        one) will be kept."
-
-    example default
-        app_id = "dbaid:AAFdgehTzw7WlXhZJsbGCLePe8RvQGYDr-I"
-        team_member_id = "dbmid:AAFdgehTzw7WlXhZJsbGCLePe8RvQGYDr-I"
-
-struct RevokeLinkedApiAppBatchArg
-    revoke_linked_app List(RevokeLinkedApiAppArg)
-
-    example default
-        revoke_linked_app = [default]
-
-struct RevokeLinkedAppStatus
-    success Boolean
-        "Result of the revoking request."
-    error_type RevokeLinkedAppError?
-        "The error cause in case of a failure."
-
-    example default
-        success = false
-        error_type = app_not_found
-
-struct RevokeLinkedAppBatchResult
-    revoke_linked_app_status List(RevokeLinkedAppStatus)
-
-    example default
-        revoke_linked_app_status = [default]
-
-struct ListTeamAppsArg
-    "Arguments for :route:`linked_apps/list_team_linked_apps`."
-    cursor String?
-        "At the first call to the :route:`linked_apps/list_team_linked_apps` the cursor shouldn't be
-        passed. Then, if the result of the call includes a cursor, the following requests should
-        include the received cursors in order to receive the next sub list of the team applications."
-
-    example default
-        cursor = "AADAQO8ZWKvBkSMXb1J9dAYVvwZ0wcvfyzIBo2e1H-_N-67pfrYKTb4oN_3LG9_ilWjblZXuiR8ubjjiQQkHq-MvDjbe_6bkcJgjnTpowrRaQA"
-
-struct ListTeamAppsResult
-    "Information returned by :route:`linked_apps/list_team_linked_apps`."
-    apps List(MemberLinkedApps)
-        "The linked applications of each member of the team."
-    has_more Boolean
-        "If true, then there are more apps available. Pass the
-        cursor to :route:`linked_apps/list_team_linked_apps` to retrieve the rest."
-    cursor String?
-        "Pass the cursor into :route:`linked_apps/list_team_linked_apps` to receive the next
-        sub list of team's applications."
-
-    example default
-        apps = [default]
-        has_more = true
-        cursor = "AADAQO8ZWKvBkSMXb1J9dAYVvwZ0wcvfyzIBo2e1H-_N-67pfrYKTb4oN_3LG9_ilWjblZXuiR8ubjjiQQkHq-MvDjbe_6bkcJgjnTpowrRaQA"
-
-route linked_apps/list_member_linked_apps (ListMemberAppsArg, ListMemberAppsResult, ListMemberAppsError)
-    "List all linked applications of the team member.
-    Note, this endpoint does not list any team-linked applications."
-
-    attrs
-        auth = "team"
-        scope = "sessions.list"
-
-route linked_apps/list_members_linked_apps (ListMembersAppsArg, ListMembersAppsResult, ListMembersAppsError)
-    "List all applications linked to the team members' accounts.
-    Note, this endpoint does not list any team-linked applications."
-
-    attrs
-        auth = "team"
-        scope = "sessions.list"
-
-route linked_apps/revoke_linked_app (RevokeLinkedApiAppArg, Void, RevokeLinkedAppError)
-    "Revoke a linked application of the team member."
-
-    attrs
-        auth = "team"
-        scope = "sessions.modify"
-
-route linked_apps/revoke_linked_app_batch (RevokeLinkedApiAppBatchArg, RevokeLinkedAppBatchResult, RevokeLinkedAppBatchError)
-    "Revoke a list of linked applications of the team members."
-
-    attrs
-        auth = "team"
-        scope = "sessions.modify"
-
-route linked_apps/list_team_linked_apps (ListTeamAppsArg, ListTeamAppsResult, ListTeamAppsError) deprecated
-    "List all applications linked to the team members' accounts.
-    Note, this endpoint doesn't list any team-linked applications."
-
-    attrs
-        auth = "team"
-        scope = "sessions.list"
-
-
-route token/get_authenticated_admin (Void, TokenGetAuthenticatedAdminResult, TokenGetAuthenticatedAdminError)
-    "Returns the member profile of the admin who generated the team access token used to make the call."
-
-    attrs
-        auth = "team"
-        scope = "team_info.read"
-
-
-route get_info (Void, TeamGetInfoResult, Void)
-    "Retrieves information about a team."
-
-    attrs
-        auth = "team"
-        scope = "team_info.read"
-
-
-union SharingAllowlistAddError
-    malformed_entry String = ""
-        "One of provided values is not valid."
-    no_entries_provided
-        "Neither single domain nor email provided."
-    too_many_entries_provided
-        "Too many entries provided within one call."
-    team_limit_reached
-        "Team entries limit reached."
-    unknown_error
-        "Unknown error."
-    entries_already_exist String = ""
-        "Entries already exists."
-
-union SharingAllowlistListContinueError
-    invalid_cursor
-        "Provided cursor is not valid."
-
-union SharingAllowlistRemoveError
-    malformed_entry String = ""
-        "One of provided values is not valid."
-    entries_do_not_exist String = ""
-        "One or more provided values do not exist."
-    no_entries_provided
-        "Neither single domain nor email provided."
-    too_many_entries_provided
-        "Too many entries provided within one call."
-    unknown_error
-        "Unknown error."
-
-struct SharingAllowlistAddArgs
-    "Structure representing Approve List entries. Domain and emails are supported.
-    At least one entry of any supported type is required."
-    domains List(String)?
-        "List of domains represented by valid string representation (RFC-1034/5)."
-    emails List(String)?
-        "List of emails represented by valid string representation (RFC-5322/822)."
-
-    example default
-        domains = ["test-domain.com", "subdomain.some.com"]
-        emails = ["adam@test-domain.com", "john@some.com"]
-
-struct SharingAllowlistAddResponse
-    "This struct is empty. The comment here is intentionally emitted to avoid indentation issues with Stone."
-
-struct SharingAllowlistListArg
-    limit UInt32(max_value=1000, min_value=1) = 1000
-        "The number of entries to fetch at one time."
-
-    example default
-        limit = 100
-
-struct SharingAllowlistListContinueArg
-    cursor String
-        "The cursor returned from a previous call to :route:`sharing_allowlist/list` or :route:`sharing_allowlist/list/continue`."
-
-    example default
-        cursor = "dGVzdF9jdXJzb3IK"
-
-struct SharingAllowlistListError
-    "This struct is empty. The comment here is intentionally emitted to avoid indentation issues with Stone."
-
-struct SharingAllowlistListResponse
-    domains List(String)
-        "List of domains represented by valid string representation (RFC-1034/5)."
-    emails List(String)
-        "List of emails represented by valid string representation (RFC-5322/822)."
-    cursor String = ""
-        "If this is nonempty, there are more entries that can be fetched with :route:`sharing_allowlist/list/continue`."
-    has_more Boolean = false
-        "if true indicates that more entries can be fetched with :route:`sharing_allowlist/list/continue`."
-
-    example default
-        domains = ["test-domain.com", "subdomain.some.com"]
-        emails = ["adam@test-domain.com", "john@some.com"]
-        cursor = "dGVzdF9jdXJzb3IK"
-        has_more = true
-
-struct SharingAllowlistRemoveArgs
-    domains List(String)?
-        "List of domains represented by valid string representation (RFC-1034/5)."
-    emails List(String)?
-        "List of emails represented by valid string representation (RFC-5322/822)."
-
-    example default
-        domains = ["test-domain.com", "subdomain.some.com"]
-        emails = ["adam@test-domain.com", "john@some.com"]
-
-struct SharingAllowlistRemoveResponse
-    "This struct is empty. The comment here is intentionally emitted to avoid indentation issues with Stone."
-
-route sharing_allowlist/add (SharingAllowlistAddArgs, SharingAllowlistAddResponse, SharingAllowlistAddError)
-    "Endpoint adds Approve List entries. Changes are effective immediately.
-    Changes are committed in transaction. In case of single validation error - all entries are rejected.
-    Valid domains (RFC-1034/5) and emails (RFC-5322/822) are accepted.
-    Added entries cannot overflow limit of 10000 entries per team.
-    Maximum 100 entries per call is allowed."
-
-    attrs
-        auth = "team"
-        is_preview = true
-        scope = "team_info.write"
-
-route sharing_allowlist/list (SharingAllowlistListArg, SharingAllowlistListResponse, SharingAllowlistListError)
-    "Lists Approve List entries for given team, from newest to oldest, returning
-    up to `limit` entries at a time. If there are more than `limit` entries
-    associated with the current team, more can be fetched by passing the
-    returned `cursor` to :route:`sharing_allowlist/list/continue`."
-
-    attrs
-        auth = "team"
-        is_preview = true
-        scope = "team_info.read"
-
-route sharing_allowlist/list/continue (SharingAllowlistListContinueArg, SharingAllowlistListResponse, SharingAllowlistListContinueError)
-    "Lists entries associated with given team, starting from a the cursor. See :route:`sharing_allowlist/list`."
-
-    attrs
-        auth = "team"
-        is_preview = true
-        scope = "team_info.read"
-
-route sharing_allowlist/remove (SharingAllowlistRemoveArgs, SharingAllowlistRemoveResponse, SharingAllowlistRemoveError)
-    "Endpoint removes Approve List entries. Changes are effective immediately.
-    Changes are committed in transaction. In case of single validation error - all entries are rejected.
-    Valid domains (RFC-1034/5) and emails (RFC-5322/822) are accepted.
-    Entries being removed have to be present on the list.
-    Maximum 1000 entries per call is allowed."
-
-    attrs
-        auth = "team"
-        is_preview = true
-        scope = "team_info.write"
-
-
-route features/get_values (FeaturesGetValuesBatchArg, FeaturesGetValuesBatchResult, FeaturesGetValuesBatchError)
-    "Get the values for one or more features. This route allows you to check your account's
-    capability for what feature you can access or what value you have for certain features.
-    Permission : Team information."
-
-    attrs
-        auth = "team"
-        scope = "team_info.read"
-
-
-alias UserQuota = UInt32(min_value=2)
-
-struct UserCustomQuotaArg
-    "User and their required custom quota in GB (1 TB = 1024 GB)."
-    user UserSelectorArg
-    quota_gb UserQuota
-
-    example default
-        user = default
-        quota_gb = 30
-
-struct UserCustomQuotaResult
-    "User and their custom quota in GB (1 TB = 1024 GB).
-    No quota returns if the user has no custom quota set."
-    user UserSelectorArg
-    quota_gb UserQuota?
-
-struct SetCustomQuotaArg
-    users_and_quotas List(UserCustomQuotaArg)
-        "List of users and their custom quotas."
-
-    example default
-        users_and_quotas = [default]
-
-union CustomQuotaError
-    "Error returned when getting member custom quota."
-    too_many_users
-        "A maximum of 1000 users can be set for a single call."
-
-union SetCustomQuotaError extends CustomQuotaError
-    "Error returned when setting member custom quota."
-    some_users_are_excluded
-        "Some of the users are on the excluded users list and can't have custom quota set."
-
-union CustomQuotaResult
-    "User custom quota."
-    success UserCustomQuotaResult
-        "User's custom quota."
-    invalid_user UserSelectorArg
-        "Invalid user (not in team)."
-
-struct CustomQuotaUsersArg
-    users List(UserSelectorArg)
-        "List of users."
-
-    example default
-        users = [default]
-
-union RemoveCustomQuotaResult
-    "User result for setting member custom quota."
-    success UserSelectorArg
-        "Successfully removed user."
-    invalid_user UserSelectorArg
-        "Invalid user (not in team)."
-
-struct ExcludedUsersUpdateArg
-    "Argument of excluded users update operation.
-    Should include a list of users to add/remove (according to endpoint),
-    Maximum size of the list is 1000 users."
-    users List(UserSelectorArg)?
-        "List of users to be added/removed."
-
-    example default
-        users = [default]
-
-union ExcludedUsersUpdateError
-    "Excluded users update error."
-    users_not_in_team
-        "At least one of the users is not part of your team."
-    too_many_users
-        "A maximum of 1000 users for each of addition/removal can be supplied."
-
-struct ExcludedUsersListArg
-    "Excluded users list argument."
-    limit UInt32(max_value=1000, min_value=1) = 1000
-        "Number of results to return per call."
-
-    example default
-        limit = 100
-
-struct ExcludedUsersListContinueArg
-    "Excluded users list continue argument."
-    cursor String
-        "Indicates from what point to get the next set of users."
-
-    example default
-        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
-
-struct ExcludedUsersListResult
-    "Excluded users list result."
-    users List(MemberProfile)
-    cursor String?
-        "Pass the cursor into :route:`member_space_limits/excluded_users/list/continue` to obtain
-        additional excluded users."
-    has_more Boolean
-        "Is true if there are additional excluded users that have not been returned
-        yet. An additional call to :route:`member_space_limits/excluded_users/list/continue` can
-        retrieve them."
-
-    example default
-        users = []
-        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
-        has_more = false
-
-union ExcludedUsersUpdateStatus
-    "Excluded users update operation status."
-    success
-        "Update successful."
-
-struct ExcludedUsersUpdateResult
-    "Excluded users update result."
-    status ExcludedUsersUpdateStatus
-        "Update status."
-
-    example default
-        status = success
-
-union ExcludedUsersListError
-    "Excluded users list error."
-    list_error
-        "An error occurred."
-
-union ExcludedUsersListContinueError
-    "Excluded users list continue error."
-    invalid_cursor
-        "The cursor is invalid."
-
-route member_space_limits/set_custom_quota (SetCustomQuotaArg, List(CustomQuotaResult), SetCustomQuotaError)
-    "Set users custom quota. Custom quota has to be at least 2GB.
-    A maximum of 1000 members can be specified in a single call.
-    Note: to apply a custom space limit, a team admin needs to set a member space limit for the team first.
-    (the team admin can check the settings here: https://www.dropbox.com/team/admin/settings/space)."
-
-    attrs
-        auth = "team"
-        scope = "members.read"
-
-route member_space_limits/remove_custom_quota (CustomQuotaUsersArg, List(RemoveCustomQuotaResult), CustomQuotaError)
-    "Remove users custom quota.
-    A maximum of 1000 members can be specified in a single call.
-    Note: to apply a custom space limit, a team admin needs to set a member space limit for the team first.
-    (the team admin can check the settings here: https://www.dropbox.com/team/admin/settings/space)."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route member_space_limits/get_custom_quota (CustomQuotaUsersArg, List(CustomQuotaResult), CustomQuotaError)
-    "Get users custom quota.
-    A maximum of 1000 members can be specified in a single call.
-    Note: to apply a custom space limit, a team admin needs to set a member space limit for the team first.
-    (the team admin can check the settings here: https://www.dropbox.com/team/admin/settings/space)."
-
-    attrs
-        auth = "team"
-        scope = "members.read"
-
-route member_space_limits/excluded_users/add (ExcludedUsersUpdateArg, ExcludedUsersUpdateResult, ExcludedUsersUpdateError)
-    "Add users to member space limits excluded users list."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route member_space_limits/excluded_users/remove (ExcludedUsersUpdateArg, ExcludedUsersUpdateResult, ExcludedUsersUpdateError)
-    "Remove users from member space limits excluded users list."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route member_space_limits/excluded_users/list (ExcludedUsersListArg, ExcludedUsersListResult, ExcludedUsersListError)
-    "List member space limits excluded users."
-
-    attrs
-        auth = "team"
-        scope = "members.read"
-
-route member_space_limits/excluded_users/list/continue (ExcludedUsersListContinueArg, ExcludedUsersListResult, ExcludedUsersListContinueError)
-    "Continue listing member space limits excluded users."
-
-    attrs
-        auth = "team"
-        scope = "members.read"
-
-
-route properties/template/add (file_properties.AddTemplateArg, file_properties.AddTemplateResult, file_properties.ModifyTemplateError) deprecated
-    "Permission : Team member file access."
-
-    attrs
-        auth = "team"
-        scope = "files.team_metadata.write"
-
-route properties/template/get (file_properties.GetTemplateArg, file_properties.GetTemplateResult, file_properties.TemplateError) deprecated
-    "Permission : Team member file access. The scope for the route is files.team_metadata.write."
-
-    attrs
-        auth = "team"
-        scope = "files.team_metadata.write"
-
-
-union AddSecondaryEmailResult
-    "Result of trying to add a secondary email to a user.
-    'success' is the only value indicating that a secondary email was successfully added to a user.
-    The other values explain the type of error that occurred, and include the email for which the error occurred."
-    success secondary_emails.SecondaryEmail
-        "Describes a secondary email that was successfully added to a user."
-    unavailable common.EmailAddress
-        "Secondary email is not available to be claimed by the user."
-    already_pending common.EmailAddress
-        "Secondary email is already a pending email for the user."
-    already_owned_by_user common.EmailAddress
-        "Secondary email is already a verified email for the user."
-    reached_limit common.EmailAddress
-        "User already has the maximum number of secondary emails allowed."
-    transient_error common.EmailAddress
-        "A transient error occurred. Please try again later."
-    too_many_updates common.EmailAddress
-        "An error occurred due to conflicting updates. Please try again later."
-    unknown_error common.EmailAddress
-        "An unknown error occurred."
-    rate_limited common.EmailAddress
-        "Too many emails are being sent to this email address. Please try again later."
-
-    example default
-        success = default
-    
-    example unavailable
-        unavailable = "alice@example.com"
-
-union UserAddResult
-    "Result of trying to add secondary emails to a user.
-    'success' is the only value indicating that a user was successfully retrieved for adding secondary emails.
-    The other values explain the type of error that occurred, and include the user for which the error occurred."
-    success UserSecondaryEmailsResult
-        "Describes a user and the results for each attempt to add a secondary email."
-    invalid_user UserSelectorArg
-        "Specified user is not a valid target for adding secondary emails."
-    unverified UserSelectorArg
-        "Secondary emails can only be added to verified users."
-    placeholder_user UserSelectorArg
-        "Secondary emails cannot be added to placeholder users."
-
-    example default
-        success = default
-    
-    example invalid
-        invalid_user = default
-
-union AddSecondaryEmailsError
-    "Error returned when adding secondary emails fails."
-    secondary_emails_disabled
-        "Secondary emails are disabled for the team."
-    too_many_emails
-        "A maximum of 20 secondary emails can be added in a single call."
-
-union ResendSecondaryEmailResult
-    "Result of trying to resend verification email to a secondary email address.
-    'success' is the only value indicating that a verification email was successfully sent.
-    The other values explain the type of error that occurred, and include the email for which the error occurred."
-    success common.EmailAddress
-        "A verification email was successfully sent to the secondary email address."
-    not_pending common.EmailAddress
-        "This secondary email address is not pending for the user."
-    rate_limited common.EmailAddress
-        "Too many emails are being sent to this email address. Please try again later."
-
-    example default
-        success = "alice@example.com"
-
-union UserResendResult
-    "Result of trying to resend verification emails to a user.
-    'success' is the only value indicating that a user was successfully retrieved for sending verification emails.
-    The other values explain the type of error that occurred, and include the user for which the error occurred."
-    success UserResendEmailsResult
-        "Describes a user and the results for each attempt to resend verification emails."
-    invalid_user UserSelectorArg
-        "Specified user is not a valid target for resending verification emails."
-
-    example default
-        success = default
-    
-    example invalid
-        invalid_user = default
-
-union DeleteSecondaryEmailResult
-    "Result of trying to delete a secondary email address.
-    'success' is the only value indicating that a secondary email was successfully deleted.
-    The other values explain the type of error that occurred, and include the email for which the error occurred."
-    success common.EmailAddress
-        "The secondary email was successfully deleted."
-    not_found common.EmailAddress
-        "The email address was not found for the user."
-    cannot_remove_primary common.EmailAddress
-        "The email address is the primary email address of the user, and cannot be removed."
-
-    example default
-        success = "alice@example.com"
-    
-    example not_found
-        not_found = "alic@example.com"
-
-union UserDeleteResult
-    "Result of trying to delete a user's secondary emails.
-    'success' is the only value indicating that a user was successfully retrieved for deleting secondary emails.
-    The other values explain the type of error that occurred, and include the user for which the error occurred."
-    success UserDeleteEmailsResult
-        "Describes a user and the results for each attempt to delete a secondary email."
-    invalid_user UserSelectorArg
-        "Specified user is not a valid target for deleting secondary emails."
-
-    example default
-        success = default
-    
-    example invalid_user
-        invalid_user = default
-
-struct UserSecondaryEmailsArg
-    "User and a list of secondary emails."
-    user UserSelectorArg
-    secondary_emails List(common.EmailAddress)
-
-    example default
-        user = default
-        secondary_emails = ["bob2@hotmail.com", "bob@inst.gov"]
-
-struct UserSecondaryEmailsResult
-    user UserSelectorArg
-    results List(AddSecondaryEmailResult)
-
-    example default
-        user = default
-        results = [default, unavailable]
-
-struct AddSecondaryEmailsArg
-    new_secondary_emails List(UserSecondaryEmailsArg)
-        "List of users and secondary emails to add."
-
-    example default
-        new_secondary_emails = [default]
-
-struct AddSecondaryEmailsResult
-    results List(UserAddResult)
-        "List of users and secondary email results."
-
-    example default
-        results = [default, invalid]
-
-struct ResendVerificationEmailArg
-    emails_to_resend List(UserSecondaryEmailsArg)
-        "List of users and secondary emails to resend verification emails to."
-
-    example default
-        emails_to_resend = [default]
-
-struct UserResendEmailsResult
-    user UserSelectorArg
-    results List(ResendSecondaryEmailResult)
-
-    example default
-        user = default
-        results = [default]
-
-struct ResendVerificationEmailResult
-    "List of users and resend results."
-    results List(UserResendResult)
-
-    example default
-        results = [default]
-
-struct DeleteSecondaryEmailsArg
-    emails_to_delete List(UserSecondaryEmailsArg)
-        "List of users and their secondary emails to delete."
-
-    example default
-        emails_to_delete = [default]
-
-struct UserDeleteEmailsResult
-    user UserSelectorArg
-    results List(DeleteSecondaryEmailResult)
-
-    example default
-        user = default
-        results = [default, not_found]
-
-struct DeleteSecondaryEmailsResult
-    results List(UserDeleteResult)
-
-    example default
-        results = [default]
-
-route members/secondary_emails/add (AddSecondaryEmailsArg, AddSecondaryEmailsResult, AddSecondaryEmailsError)
-    "Add secondary emails to users.
-    Permission : Team member management.
-    Emails that are on verified domains will be verified automatically.
-    For each email address not on a verified domain a verification email will be sent."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/secondary_emails/resend_verification_emails (ResendVerificationEmailArg, ResendVerificationEmailResult, Void)
-    "Resend secondary email verification emails.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/secondary_emails/delete (DeleteSecondaryEmailsArg, DeleteSecondaryEmailsResult, Void)
-    "Delete secondary emails from users
-    Permission : Team member management.
-    Users will be notified of deletions of verified secondary emails at both the secondary email and their primary email."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-
-alias NumberPerDay = List(UInt64?)
-
-union TeamReportFailureReason
-    temporary_error
-        "We couldn't create the report, but we think this was a fluke. Everything should work if you try it again."
-    many_reports_at_once
-        "Too many other reports are being created right now. Try creating this report again once the others finish."
-    too_much_data
-        "We couldn't create the report. Try creating the report again with less data."
-
-    example default
-        many_reports_at_once = null
-
-union DateRangeError
-    "Errors that can originate from problems in input arguments to reports."
-
-struct DateRange
-    "Input arguments that can be provided for most reports."
-    start_date common.Date?
-        "Optional starting date (inclusive). If start_date is None or too long ago, this field will
-        be set to 6 months ago."
-    end_date common.Date?
-        "Optional ending date (exclusive)."
-
-struct StorageBucket
-    "Describes the number of users in a specific storage bucket."
-    bucket String
-        "The name of the storage bucket.
-        For example, '1G' is a bucket of users with storage size up to 1 Giga."
-    users UInt64
-        "The number of people whose storage is in the range of this storage bucket."
-
-    example default
-        bucket = "1G"
-        users = 21
-
-struct BaseDfbReport
-    "Base report structure."
-    start_date String
-        "First date present in the results as 'YYYY-MM-DD' or None."
-
-struct GetStorageReport extends BaseDfbReport
-    "Storage Report Result.
-    Each of the items in the storage report is an array of values, one value per day.
-    If there is no data for a day, then the value will be None."
-    total_usage NumberPerDay
-        "Sum of the shared, unshared, and datastore usages, for each day."
-    shared_usage NumberPerDay
-        "Array of the combined size (bytes) of team members' shared folders, for each day."
-    unshared_usage NumberPerDay
-        "Array of the combined size (bytes) of team members' root namespaces, for each day."
-    shared_folders NumberPerDay
-        "Array of the number of shared folders owned by team members, for each day."
-    member_storage_map List(List(StorageBucket))
-        "Array of storage summaries of team members' account sizes.
-        Each storage summary is an array of key, value pairs, where each pair describes
-        a storage bucket.
-        The key indicates the upper bound of the bucket and the value is the
-        number of users in that bucket. There is one such summary per day.
-        If there is no data for a day, the storage summary will be empty."
-
-struct GetActivityReport extends BaseDfbReport
-    "Activity Report Result.
-    Each of the items in the storage report is an array of values, one value per day.
-    If there is no data for a day, then the value will be None."
-    adds NumberPerDay
-        "Array of total number of adds by team members."
-    edits NumberPerDay
-        "Array of number of edits by team members.
-        If the same user edits the same file multiple times this is counted as a single edit."
-    deletes NumberPerDay
-        "Array of total number of deletes by team members."
-    active_users_28_day NumberPerDay
-        "Array of the number of users who have been active in the last 28 days."
-    active_users_7_day NumberPerDay
-        "Array of the number of users who have been active in the last week."
-    active_users_1_day NumberPerDay
-        "Array of the number of users who have been active in the last day."
-    active_shared_folders_28_day NumberPerDay
-        "Array of the number of shared folders with some activity in the last 28 days."
-    active_shared_folders_7_day NumberPerDay
-        "Array of the number of shared folders with some activity in the last week."
-    active_shared_folders_1_day NumberPerDay
-        "Array of the number of shared folders with some activity in the last day."
-    shared_links_created NumberPerDay
-        "Array of the number of shared links created."
-    shared_links_viewed_by_team NumberPerDay
-        "Array of the number of views by team users to shared links created by the team."
-    shared_links_viewed_by_outside_user NumberPerDay
-        "Array of the number of views by users outside of the team to shared links created by the team."
-    shared_links_viewed_by_not_logged_in NumberPerDay
-        "Array of the number of views by non-logged-in users to shared links created by the team."
-    shared_links_viewed_total NumberPerDay
-        "Array of the total number of views to shared links created by the team."
-
-struct GetMembershipReport extends BaseDfbReport
-    "Membership Report Result.
-    Each of the items in the storage report is an array of values, one value per day.
-    If there is no data for a day, then the value will be None."
-    team_size NumberPerDay
-        "Team size, for each day."
-    pending_invites NumberPerDay
-        "The number of pending invites to the team, for each day."
-    members_joined NumberPerDay
-        "The number of members that joined the team, for each day."
-    suspended_members NumberPerDay
-        "The number of suspended team members, for each day."
-    licenses NumberPerDay
-        "The total number of licenses the team has, for each day."
-
-struct DevicesActive
-    "Each of the items is an array of values, one value per day.
-    The value is the number of devices active within a time window, ending with that day.
-    If there is no data for a day, then the value will be None."
-    windows NumberPerDay
-        "Array of number of linked windows (desktop) clients with activity."
-    macos NumberPerDay
-        "Array of number of linked mac (desktop) clients with activity."
-    linux NumberPerDay
-        "Array of number of linked linus (desktop) clients with activity."
-    ios NumberPerDay
-        "Array of number of linked ios devices with activity."
-    android NumberPerDay
-        "Array of number of linked android devices with activity."
-    other NumberPerDay
-        "Array of number of other linked devices (blackberry, windows phone, etc)
-        with activity."
-    total NumberPerDay
-        "Array of total number of linked clients with activity."
-
-struct GetDevicesReport extends BaseDfbReport
-    "Devices Report Result. Contains subsections for different time ranges of activity.
-    Each of the items in each subsection of the storage report is an array of values,
-    one value per day.
-    If there is no data for a day, then the value will be None."
-    active_1_day DevicesActive
-        "Report of the number of devices active in the last day."
-    active_7_day DevicesActive
-        "Report of the number of devices active in the last 7 days."
-    active_28_day DevicesActive
-        "Report of the number of devices active in the last 28 days."
-
-
-route reports/get_storage (DateRange, GetStorageReport, DateRangeError) deprecated
-    "Retrieves reporting data about a team's storage usage.
-    Deprecated: Will be removed on July 1st 2021."
-
-    attrs
-        auth = "team"
-        scope = "team_info.read"
-
-
-route reports/get_activity (DateRange, GetActivityReport, DateRangeError) deprecated
-    "Retrieves reporting data about a team's user activity.
-    Deprecated: Will be removed on July 1st 2021."
-
-    attrs
-        auth = "team"
-        scope = "team_info.read"
-
-
-route reports/get_membership (DateRange, GetMembershipReport, DateRangeError) deprecated
-    "Retrieves reporting data about a team's membership.
-    Deprecated: Will be removed on July 1st 2021."
-
-    attrs
-        auth = "team"
-        scope = "team_info.read"
-
-
-route reports/get_devices (DateRange, GetDevicesReport, DateRangeError) deprecated
-    "Retrieves reporting data about a team's linked devices.
-    Deprecated: Will be removed on July 1st 2021."
-
-    attrs
-        auth = "team"
-        scope = "team_info.read"
+        account_id = "dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc"
+        email = "mary@lamb.com"
+        email_verified = true
+        secondary_emails = [default, second_sec_email, third_sec_email]
+        status = active
+        name = default
+        membership_type = full
+        joined_on = "2015-05-12T15:50:38Z"
+        profile_photo_url = "https://dl-web.dropbox.com/account_photo/get/dbaphid%3AAAHWGmIXV3sUuOmBfTz0wPsiqHUpBWvv3ZA?vers=1556069330102&size=128x128"
+
+struct TeamMemberProfile extends MemberProfile
+    "Profile of a user as a member of a team."
+    groups List(team_common.GroupId)
+        "List of group IDs of groups that the user belongs to."
+    member_folder_id common.NamespaceId
+        "The namespace id of the user's member folder."
+    root_folder_id common.NamespaceId
+        "The namespace id of the user's root folder."
+
+    example default
+        team_member_id = "dbmid:FDFSVF-DFSDF"
+        account_id = "dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc"
+        external_id = "244423"
+        email = "tami@seagull.com"
+        email_verified = false
+        secondary_emails = [third_sec_email, default]
+        status = active
+        name = default
+        groups = ["g:e2db7665347abcd600000000001a2b3c"]
+        membership_type = full
+        joined_on = "2015-05-12T15:50:38Z"
+        member_folder_id = "20"
+        root_folder_id = "30"
+        profile_photo_url = "https://dl-web.dropbox.com/account_photo/get/dbaphid%3AAAHWGmIXV3sUuOmBfTz0wPsiqHUpBWvv3ZA?vers=1556069330102&size=128x128"
 
 
 union DesktopPlatform
@@ -1983,7 +583,7 @@ union_closed TeamFolderArchiveLaunch extends async.LaunchResultBase
 
     example default
         complete = default
-    
+
     example async_job_id
         async_job_id = "34g93hh34h04y384084"
 
@@ -2116,6 +716,537 @@ route team_folder/update_sync_settings (TeamFolderUpdateSyncSettingsArg, TeamFol
         scope = "team_data.content.write"
 
 
+alias LegalHoldId = String(pattern="^pid_dbhid:.+")
+
+alias LegalHoldPolicyName = String(max_length=140)
+
+alias LegalHoldPolicyDescription = String(max_length=501)
+
+alias Path = String(pattern="(/(.|[\\r\\n])*)?")
+
+alias LegalHoldsPolicyCreateResult = LegalHoldPolicy
+
+alias LegalHoldsGetPolicyResult = LegalHoldPolicy
+
+alias ListHeldRevisionCursor = String(min_length=1)
+
+alias LegalHoldsPolicyUpdateResult = LegalHoldPolicy
+
+union LegalHoldStatus
+    active
+        "The legal hold policy is active."
+    released
+        "The legal hold policy was released."
+    activating
+        "The legal hold policy is activating."
+    updating
+        "The legal hold policy is updating."
+    exporting
+        "The legal hold policy is exporting."
+    releasing
+        "The legal hold policy is releasing."
+
+union LegalHoldsError
+    unknown_legal_hold_error
+        "There has been an unknown legal hold error."
+    insufficient_permissions
+        "You don't have permissions to perform this action."
+
+union LegalHoldsPolicyCreateError extends LegalHoldsError
+    start_date_is_later_than_end_date
+        "Start date must be earlier than end date."
+    empty_members_list
+        "The users list must have at least one user."
+    invalid_members
+        "Some members in the members list are not valid to be placed under legal hold."
+    number_of_users_on_hold_is_greater_than_hold_limitation
+        "You cannot add more than 5 users in a legal hold."
+    transient_error
+        "Temporary infrastructure failure, please retry."
+    name_must_be_unique
+        "The name provided is already in use by another legal hold."
+    team_exceeded_legal_hold_quota
+        "Team exceeded legal hold quota."
+    invalid_date
+        "The provided date is invalid."
+
+union LegalHoldsGetPolicyError extends LegalHoldsError
+    legal_hold_policy_not_found
+        "Legal hold policy does not exist for :field:`LegalHoldsGetPolicyArg.id`."
+
+union LegalHoldsListPoliciesError extends LegalHoldsError
+    transient_error
+        "Temporary infrastructure failure, please retry."
+
+union LegalHoldsListHeldRevisionsError extends LegalHoldsError
+    transient_error
+        "Temporary infrastructure failure, please retry."
+    legal_hold_still_empty
+        "The legal hold is not holding any revisions yet."
+    inactive_legal_hold
+        "Trying to list revisions for an inactive legal hold."
+
+union LegalHoldsListHeldRevisionsContinueError
+    unknown_legal_hold_error
+        "There has been an unknown legal hold error."
+    transient_error
+        "Temporary infrastructure failure, please retry."
+    reset
+        "Indicates that the cursor has been invalidated. Call
+        :route:`legal_holds/list_held_revisions_continue` again with an empty cursor to obtain a new cursor."
+
+union LegalHoldsPolicyUpdateError extends LegalHoldsError
+    transient_error
+        "Temporary infrastructure failure, please retry."
+    inactive_legal_hold
+        "Trying to release an inactive legal hold."
+    legal_hold_performing_another_operation
+        "Legal hold is currently performing another operation."
+    invalid_members
+        "Some members in the members list are not valid to be placed under legal hold."
+    number_of_users_on_hold_is_greater_than_hold_limitation
+        "You cannot add more than 5 users in a legal hold."
+    empty_members_list
+        "The users list must have at least one user."
+    name_must_be_unique
+        "The name provided is already in use by another legal hold."
+    legal_hold_policy_not_found
+        "Legal hold policy does not exist for :field:`LegalHoldsPolicyUpdateArg.id`."
+
+union LegalHoldsPolicyReleaseError extends LegalHoldsError
+    legal_hold_performing_another_operation
+        "Legal hold is currently performing another operation."
+    legal_hold_already_releasing
+        "Legal hold is currently performing a release or is already released."
+    legal_hold_policy_not_found
+        "Legal hold policy does not exist for :field:`LegalHoldsPolicyReleaseArg.id`."
+
+struct MembersInfo
+    team_member_ids List(team_common.TeamMemberId)
+        "Team member IDs of the users under this hold."
+    permanently_deleted_users UInt64
+        "The number of permanently deleted users that were under this hold."
+
+    example default
+        team_member_ids = ["dbmid:efgh5678"]
+        permanently_deleted_users = 2
+
+struct LegalHoldPolicy
+    id LegalHoldId
+        "The legal hold id."
+    name LegalHoldPolicyName
+        "Policy name."
+    description LegalHoldPolicyDescription?
+        "A description of the legal hold policy."
+    activation_time common.DropboxTimestamp?
+        "The time at which the legal hold was activated."
+    members MembersInfo
+        "Team members IDs and number of permanently deleted members under hold."
+    status LegalHoldStatus
+        "The current state of the hold."
+    start_date common.DropboxTimestamp
+        "Start date of the legal hold policy."
+    end_date common.DropboxTimestamp?
+        "End date of the legal hold policy."
+
+    example default
+        id = "pid_dbhid:abcd1234"
+        name = "acme cfo policy"
+        activation_time = "2016-01-20T00:00:10Z"
+        members = default
+        status = active
+        start_date = "2016-01-01T00:00:00Z"
+        end_date = "2017-12-31T00:00:00Z"
+
+struct LegalHoldsPolicyCreateArg
+    name LegalHoldPolicyName
+        "Policy name."
+    description LegalHoldPolicyDescription?
+        "A description of the legal hold policy."
+    members List(team_common.TeamMemberId)
+        "List of team member IDs added to the hold."
+    start_date common.DropboxTimestamp?
+        "start date of the legal hold policy."
+    end_date common.DropboxTimestamp?
+        "end date of the legal hold policy."
+
+    example default
+        name = "acme cfo policy"
+        members = ["dbmid:FDFSVF-DFSDF"]
+        start_date = "2016-01-01T00:00:00Z"
+        end_date = "2017-12-31T00:00:00Z"
+
+struct LegalHoldsGetPolicyArg
+    id LegalHoldId
+        "The legal hold Id."
+
+    example default
+        id = "pid_dbhid:abcd1234"
+
+struct LegalHoldsListPoliciesArg
+    include_released Boolean = false
+        "Whether to return holds that were released."
+
+    example default
+        include_released = false
+
+struct LegalHoldsListPoliciesResult
+    policies List(LegalHoldPolicy)
+
+    example default
+        policies = [default]
+
+struct LegalHoldsListHeldRevisionsArg
+    id LegalHoldId
+        "The legal hold Id."
+
+    example default
+        id = "pid_dbhid:abcd1234"
+
+struct LegalHoldHeldRevisionMetadata
+    new_filename String
+        "The held revision filename."
+    original_revision_id files.Rev
+        "The id of the held revision."
+    original_file_path Path
+        "The original path of the held revision."
+    server_modified common.DropboxTimestamp
+        "The last time the file was modified on Dropbox."
+    author_member_id team_common.TeamMemberId
+        "The member id of the revision's author."
+    author_member_status TeamMemberStatus
+        "The member status of the revision's author."
+    author_email common.EmailAddress
+        "The email address of the held revision author."
+    file_type String
+        "The type of the held revision's file."
+    size UInt64
+        "The file size in bytes."
+    content_hash files.Sha256HexHash
+        "A hash of the file content. This field can be used to verify data integrity. For more
+        information see our :link:`Content hash https://www.dropbox.com/developers/reference/content-hash` page."
+
+    example default
+        new_filename = "111_222.pdf"
+        original_revision_id = "ab2rij4i5ojgfd"
+        original_file_path = "/a.pdf"
+        server_modified = "2019-08-12T12:08:52Z"
+        author_member_id = "dbmid:abcd1234abcd1234abcd1234abcd1234a23"
+        author_member_status = active
+        author_email = "a@a.com"
+        file_type = "Document"
+        size = 3
+        content_hash = "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234"
+
+struct LegalHoldsListHeldRevisionResult
+    entries List(LegalHoldHeldRevisionMetadata)
+        "List of file entries that under the hold."
+    cursor ListHeldRevisionCursor?
+        "The cursor idicates where to continue reading file metadata entries for the next API call. When there are no more entries, the cursor will return none.
+        Pass the cursor into
+        /2/team/legal_holds/list_held_revisions/continue."
+    has_more Boolean
+        "True if there are more file entries that haven't been returned. You can retrieve them with a call to /legal_holds/list_held_revisions_continue."
+
+    example default
+        entries = [default]
+        has_more = false
+
+struct LegalHoldsListHeldRevisionsContinueArg
+    id LegalHoldId
+        "The legal hold Id."
+    cursor ListHeldRevisionCursor?
+        "The cursor idicates where to continue reading file metadata entries for the next API call. When there are no more entries, the cursor will return none."
+
+    example default
+        id = "pid_dbhid:abcd1234"
+
+struct LegalHoldsPolicyUpdateArg
+    id LegalHoldId
+        "The legal hold Id."
+    name LegalHoldPolicyName?
+        "Policy new name."
+    description LegalHoldPolicyDescription?
+        "Policy new description."
+    members List(team_common.TeamMemberId)?
+        "List of team member IDs to apply the policy on."
+
+    example default
+        id = "pid_dbhid:abcd1234"
+        members = ["dbmid:FDFSVF-DFSDF"]
+
+struct LegalHoldsPolicyReleaseArg
+    id LegalHoldId
+        "The legal hold Id."
+
+    example default
+        id = "pid_dbhid:abcd1234"
+
+route legal_holds/create_policy (LegalHoldsPolicyCreateArg, LegalHoldsPolicyCreateResult, LegalHoldsPolicyCreateError)
+    "Creates new legal hold policy.
+    Note: Legal Holds is a paid add-on. Not all teams have the feature.
+    Permission : Team member file access."
+
+    attrs
+        auth = "team"
+        scope = "team_data.governance.write"
+
+route legal_holds/get_policy (LegalHoldsGetPolicyArg, LegalHoldsGetPolicyResult, LegalHoldsGetPolicyError)
+    "Gets a legal hold by Id.
+    Note: Legal Holds is a paid add-on. Not all teams have the feature.
+    Permission : Team member file access."
+
+    attrs
+        auth = "team"
+        scope = "team_data.governance.write"
+
+route legal_holds/list_policies (LegalHoldsListPoliciesArg, LegalHoldsListPoliciesResult, LegalHoldsListPoliciesError)
+    "Lists legal holds on a team.
+    Note: Legal Holds is a paid add-on. Not all teams have the feature.
+    Permission : Team member file access."
+
+    attrs
+        auth = "team"
+        scope = "team_data.governance.write"
+
+route legal_holds/list_held_revisions (LegalHoldsListHeldRevisionsArg, LegalHoldsListHeldRevisionResult, LegalHoldsListHeldRevisionsError)
+    "List the file metadata that's under the hold.
+    Note: Legal Holds is a paid add-on. Not all teams have the feature.
+    Permission : Team member file access."
+
+    attrs
+        auth = "team"
+        scope = "team_data.governance.write"
+
+route legal_holds/list_held_revisions_continue (LegalHoldsListHeldRevisionsContinueArg, LegalHoldsListHeldRevisionResult, LegalHoldsListHeldRevisionsError)
+    "Continue listing the file metadata that's under the hold.
+    Note: Legal Holds is a paid add-on. Not all teams have the feature.
+    Permission : Team member file access."
+
+    attrs
+        auth = "team"
+        scope = "team_data.governance.write"
+
+route legal_holds/update_policy (LegalHoldsPolicyUpdateArg, LegalHoldsPolicyUpdateResult, LegalHoldsPolicyUpdateError)
+    "Updates a legal hold.
+    Note: Legal Holds is a paid add-on. Not all teams have the feature.
+    Permission : Team member file access."
+
+    attrs
+        auth = "team"
+        scope = "team_data.governance.write"
+
+route legal_holds/release_policy (LegalHoldsPolicyReleaseArg, Void, LegalHoldsPolicyReleaseError)
+    "Releases a legal hold by Id.
+    Note: Legal Holds is a paid add-on. Not all teams have the feature.
+    Permission : Team member file access."
+
+    attrs
+        auth = "team"
+        scope = "team_data.governance.write"
+
+
+route members/delete_former_member_files (MembersFormerMemberArg, Void, MembersDeleteFormerMemberFilesError)
+    "Permanently delete the files of a user who has been removed from the team. After permanent
+    deletion, those files will not be available to be transferred to another team member.
+    Permission : Team member management
+    Exactly one of team_member_id, email, or external_id must be provided to identify the user account."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/get_available_team_member_roles (Void, MembersGetAvailableTeamMemberRolesResult, Void)
+    "Get available TeamMemberRoles for the connected team. To be used with :route:`members/set_admin_permissions:2`.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "members.read"
+
+route members/get_info (MembersGetInfoArgs, MembersGetInfoResult, MembersGetInfoError)
+    "Returns information about multiple team members.
+    Permission : Team information
+    This endpoint will return :field:`MembersGetInfoItem.id_not_found`,
+    for IDs (or emails) that cannot be matched to a valid team member."
+
+    attrs
+        auth = "team"
+        scope = "members.read"
+
+route members/get_info:2 (MembersGetInfoV2Arg, MembersGetInfoV2Result, MembersGetInfoError)
+    "Returns information about multiple team members.
+    Permission : Team information
+    This endpoint will return :field:`MembersGetInfoItem.id_not_found`,
+    for IDs (or emails) that cannot be matched to a valid team member."
+
+    attrs
+        auth = "team"
+        scope = "members.read"
+
+route members/list (MembersListArg, MembersListResult, MembersListError)
+    "Lists members of a team.
+    Permission : Team information."
+
+    attrs
+        auth = "team"
+        scope = "members.read"
+
+route members/list/continue (MembersListContinueArg, MembersListResult, MembersListContinueError)
+    "Once a cursor has been retrieved from :route:`members/list`, use this to paginate
+    through all team members.
+    Permission : Team information."
+
+    attrs
+        auth = "team"
+        scope = "members.read"
+
+route members/list/continue:2 (MembersListContinueArg, MembersListV2Result, MembersListContinueError)
+    "Once a cursor has been retrieved from :route:`members/list:2`, use this to paginate
+    through all team members.
+    Permission : Team information."
+
+    attrs
+        auth = "team"
+        scope = "members.read"
+
+route members/list:2 (MembersListArg, MembersListV2Result, MembersListError)
+    "Lists members of a team.
+    Permission : Team information."
+
+    attrs
+        auth = "team"
+        scope = "members.read"
+
+route members/move_former_member_files (MembersDataTransferArg, async.LaunchEmptyResult, MembersTransferFormerMembersFilesError)
+    "Moves removed member's files to a different member. This endpoint initiates an asynchronous job. To obtain the final result
+    of the job, the client should periodically poll :route:`members/move_former_member_files/job_status/check`.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/move_former_member_files/job_status/check (async.PollArg, async.PollEmptyResult, async.PollError)
+    "Once an async_job_id is returned from :route:`members/move_former_member_files` ,
+    use this to poll the status of the asynchronous request.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/remove (MembersRemoveArg, async.LaunchEmptyResult, MembersRemoveError)
+    "Removes a member from a team.
+    Permission : Team member management
+    Exactly one of team_member_id, email, or external_id must be provided to identify the user account.
+    Accounts can be recovered via :route:`members/recover` for a 7 day period
+    or until the account has been permanently deleted or transferred to another account
+    (whichever comes first). Calling :route:`members/add` while a user is still recoverable
+    on your team will return with :field:`MemberAddResult.user_already_on_team`.
+    Accounts can have their files transferred via the admin console for a limited time, based on the version history
+    length associated with the team (180 days for most teams).
+    Accounts can have their stacks transferred through the admin console. This only transfers stacks that they have created.
+    This endpoint may initiate an asynchronous job. To obtain the final result
+    of the job, the client should periodically poll :route:`members/remove/job_status/get`."
+
+    attrs
+        auth = "team"
+        scope = "members.delete"
+
+route members/remove/job_status/get (async.PollArg, async.PollEmptyResult, async.PollError)
+    "Once an async_job_id is returned from :route:`members/remove` ,
+    use this to poll the status of the asynchronous request.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "members.delete"
+
+route members/set_admin_permissions (MembersSetPermissionsArg, MembersSetPermissionsResult, MembersSetPermissionsError)
+    "Updates a team member's permissions.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/set_admin_permissions:2 (MembersSetPermissions2Arg, MembersSetPermissions2Result, MembersSetPermissions2Error)
+    "Updates a team member's permissions.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/suspend (MembersDeactivateArg, Void, MembersSuspendError)
+    "Suspend a member from a team.
+    Permission : Team member management
+    Exactly one of team_member_id, email, or external_id must be provided to identify the user account."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/unsuspend (MembersUnsuspendArg, Void, MembersUnsuspendError)
+    "Unsuspend a member from a team.
+    Permission : Team member management
+    Exactly one of team_member_id, email, or external_id must be provided to identify the user account."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+
+route members/delete_profile_photo (MembersDeleteProfilePhotoArg, TeamMemberInfo, MembersDeleteProfilePhotoError)
+    "Deletes a team member's profile photo.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/delete_profile_photo:2 (MembersDeleteProfilePhotoArg, TeamMemberInfoV2Result, MembersDeleteProfilePhotoError)
+    "Deletes a team member's profile photo.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/set_profile (MembersSetProfileArg, TeamMemberInfo, MembersSetProfileError)
+    "Updates a team member's profile.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/set_profile:2 (MembersSetProfileArg, TeamMemberInfoV2Result, MembersSetProfileError)
+    "Updates a team member's profile.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/set_profile_photo (MembersSetProfilePhotoArg, TeamMemberInfo, MembersSetProfilePhotoError)
+    "Updates a team member's profile photo.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/set_profile_photo:2 (MembersSetProfilePhotoArg, TeamMemberInfoV2Result, MembersSetProfilePhotoError)
+    "Updates a team member's profile photo.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+
 route members/recover (MembersRecoverArg, Void, MembersRecoverError)
     "Recover a deleted member.
     Permission : Team member management
@@ -2124,6 +1255,66 @@ route members/recover (MembersRecoverArg, Void, MembersRecoverError)
     attrs
         auth = "team"
         scope = "members.delete"
+
+
+route members/add (MembersAddArg, MembersAddLaunch, Void)
+    "Adds members to a team.
+    Permission : Team member management
+    A maximum of 20 members can be specified in a single call.
+    If no Dropbox account exists with the email address specified, a new Dropbox account will
+    be created with the given email address, and that account will be invited to the team.
+    If a personal Dropbox account exists with the email address specified in the call,
+    this call will create a placeholder Dropbox account for the user on the team and send an
+    email inviting the user to migrate their existing personal account onto the team.
+    Team member management apps are required to set an initial given_name and surname for a
+    user to use in the team invitation and for 'Perform as team member' actions taken on
+    the user before they become 'active'."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/add/job_status/get (async.PollArg, MembersAddJobStatus, async.PollError)
+    "Once an async_job_id is returned from :route:`members/add` ,
+    use this to poll the status of the asynchronous request.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/add/job_status/get:2 (async.PollArg, MembersAddJobStatusV2Result, async.PollError)
+    "Once an async_job_id is returned from :route:`members/add:2` ,
+    use this to poll the status of the asynchronous request.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/add:2 (MembersAddV2Arg, MembersAddLaunchV2Result, Void)
+    "Adds members to a team.
+    Permission : Team member management
+    A maximum of 20 members can be specified in a single call.
+    If no Dropbox account exists with the email address specified, a new Dropbox account will
+    be created with the given email address, and that account will be invited to the team.
+    If a personal Dropbox account exists with the email address specified in the call,
+    this call will create a placeholder Dropbox account for the user on the team and send an
+    email inviting the user to migrate their existing personal account onto the team."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/send_welcome_email (UserSelectorArg, Void, MembersSendWelcomeError)
+    "Sends welcome email to pending team member.
+    Permission : Team member management
+    Exactly one of team_member_id, email, or external_id must be provided to identify the user account.
+    No-op if team member is not pending."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
 
 
 alias MembersGetInfoResult = List(MembersGetInfoItem)
@@ -2753,81 +1944,21 @@ struct TeamMemberRole
         role_id = "pid_dbtmr:2345"
         name = "Team admin"
         description = "User can do most user provisioning, de-provisioning and management."
-    
+
     example team_member_role_user_management
         role_id = "pid_dbtmr:3456"
         name = "User management admin"
         description = "Add, remove, and manage member accounts."
-    
+
     example team_member_role_support
         role_id = "pid_dbtmr:4567"
         name = "Support admin"
         description = "Help members with limited tasks, including password reset."
-    
+
     example team_member_role_billing
         role_id = "pid_dbtmr:5678"
         name = "Billing admin"
         description = "Make payments and renew contracts."
-
-
-route members/add (MembersAddArg, MembersAddLaunch, Void)
-    "Adds members to a team.
-    Permission : Team member management
-    A maximum of 20 members can be specified in a single call.
-    If no Dropbox account exists with the email address specified, a new Dropbox account will
-    be created with the given email address, and that account will be invited to the team.
-    If a personal Dropbox account exists with the email address specified in the call,
-    this call will create a placeholder Dropbox account for the user on the team and send an
-    email inviting the user to migrate their existing personal account onto the team.
-    Team member management apps are required to set an initial given_name and surname for a
-    user to use in the team invitation and for 'Perform as team member' actions taken on
-    the user before they become 'active'."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/add/job_status/get (async.PollArg, MembersAddJobStatus, async.PollError)
-    "Once an async_job_id is returned from :route:`members/add` ,
-    use this to poll the status of the asynchronous request.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/add/job_status/get:2 (async.PollArg, MembersAddJobStatusV2Result, async.PollError)
-    "Once an async_job_id is returned from :route:`members/add:2` ,
-    use this to poll the status of the asynchronous request.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/add:2 (MembersAddV2Arg, MembersAddLaunchV2Result, Void)
-    "Adds members to a team.
-    Permission : Team member management
-    A maximum of 20 members can be specified in a single call.
-    If no Dropbox account exists with the email address specified, a new Dropbox account will
-    be created with the given email address, and that account will be invited to the team.
-    If a personal Dropbox account exists with the email address specified in the call,
-    this call will create a placeholder Dropbox account for the user on the team and send an
-    email inviting the user to migrate their existing personal account onto the team."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/send_welcome_email (UserSelectorArg, Void, MembersSendWelcomeError)
-    "Sends welcome email to pending team member.
-    Permission : Team member management
-    Exactly one of team_member_id, email, or external_id must be provided to identify the user account.
-    No-op if team member is not pending."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
 
 
 union Feature
@@ -2854,16 +1985,16 @@ union FeatureValue
 
     example uploadRateLimited
         upload_api_rate_limit = limited
-    
+
     example hasTeamSharedDropbox
         has_team_shared_dropbox = default
-    
+
     example hasTeamFileEvents
         has_team_file_events = ex_no_file_events
-    
+
     example HasTeamSelectiveSync
         has_team_selective_sync = default
-    
+
     example hasDistinctMemberHomes
         has_distinct_member_homes = default
 
@@ -2933,7 +2064,7 @@ union_closed UserSelectorArg
 
     example default
         team_member_id = "dbmid:efgh5678"
-    
+
     example email
         email = "dan@hotmail.com"
 
@@ -2995,636 +2126,1514 @@ struct TokenGetAuthenticatedAdminResult
         admin_profile = default
 
 
-route members/delete_profile_photo (MembersDeleteProfilePhotoArg, TeamMemberInfo, MembersDeleteProfilePhotoError)
-    "Deletes a team member's profile photo.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/delete_profile_photo:2 (MembersDeleteProfilePhotoArg, TeamMemberInfoV2Result, MembersDeleteProfilePhotoError)
-    "Deletes a team member's profile photo.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/set_profile (MembersSetProfileArg, TeamMemberInfo, MembersSetProfileError)
-    "Updates a team member's profile.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/set_profile:2 (MembersSetProfileArg, TeamMemberInfoV2Result, MembersSetProfileError)
-    "Updates a team member's profile.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/set_profile_photo (MembersSetProfilePhotoArg, TeamMemberInfo, MembersSetProfilePhotoError)
-    "Updates a team member's profile photo.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/set_profile_photo:2 (MembersSetProfilePhotoArg, TeamMemberInfoV2Result, MembersSetProfilePhotoError)
-    "Updates a team member's profile photo.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-
-route members/delete_former_member_files (MembersFormerMemberArg, Void, MembersDeleteFormerMemberFilesError)
-    "Permanently delete the files of a user who has been removed from the team. After permanent
-    deletion, those files will not be available to be transferred to another team member.
-    Permission : Team member management
-    Exactly one of team_member_id, email, or external_id must be provided to identify the user account."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/get_available_team_member_roles (Void, MembersGetAvailableTeamMemberRolesResult, Void)
-    "Get available TeamMemberRoles for the connected team. To be used with :route:`members/set_admin_permissions:2`.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "members.read"
-
-route members/get_info (MembersGetInfoArgs, MembersGetInfoResult, MembersGetInfoError)
-    "Returns information about multiple team members.
-    Permission : Team information
-    This endpoint will return :field:`MembersGetInfoItem.id_not_found`,
-    for IDs (or emails) that cannot be matched to a valid team member."
-
-    attrs
-        auth = "team"
-        scope = "members.read"
-
-route members/get_info:2 (MembersGetInfoV2Arg, MembersGetInfoV2Result, MembersGetInfoError)
-    "Returns information about multiple team members.
-    Permission : Team information
-    This endpoint will return :field:`MembersGetInfoItem.id_not_found`,
-    for IDs (or emails) that cannot be matched to a valid team member."
-
-    attrs
-        auth = "team"
-        scope = "members.read"
-
-route members/list (MembersListArg, MembersListResult, MembersListError)
-    "Lists members of a team.
+route features/get_values (FeaturesGetValuesBatchArg, FeaturesGetValuesBatchResult, FeaturesGetValuesBatchError)
+    "Get the values for one or more features. This route allows you to check your account's
+    capability for what feature you can access or what value you have for certain features.
     Permission : Team information."
 
     attrs
         auth = "team"
-        scope = "members.read"
+        scope = "team_info.read"
 
-route members/list/continue (MembersListContinueArg, MembersListResult, MembersListContinueError)
-    "Once a cursor has been retrieved from :route:`members/list`, use this to paginate
-    through all team members.
-    Permission : Team information."
 
-    attrs
-        auth = "team"
-        scope = "members.read"
-
-route members/list/continue:2 (MembersListContinueArg, MembersListV2Result, MembersListContinueError)
-    "Once a cursor has been retrieved from :route:`members/list:2`, use this to paginate
-    through all team members.
-    Permission : Team information."
+route get_info (Void, TeamGetInfoResult, Void)
+    "Retrieves information about a team."
 
     attrs
         auth = "team"
-        scope = "members.read"
+        scope = "team_info.read"
 
-route members/list:2 (MembersListArg, MembersListV2Result, MembersListError)
-    "Lists members of a team.
-    Permission : Team information."
 
-    attrs
-        auth = "team"
-        scope = "members.read"
-
-route members/move_former_member_files (MembersDataTransferArg, async.LaunchEmptyResult, MembersTransferFormerMembersFilesError)
-    "Moves removed member's files to a different member. This endpoint initiates an asynchronous job. To obtain the final result
-    of the job, the client should periodically poll :route:`members/move_former_member_files/job_status/check`.
-    Permission : Team member management."
+route token/get_authenticated_admin (Void, TokenGetAuthenticatedAdminResult, TokenGetAuthenticatedAdminError)
+    "Returns the member profile of the admin who generated the team access token used to make the call."
 
     attrs
         auth = "team"
-        scope = "members.write"
+        scope = "team_info.read"
 
-route members/move_former_member_files/job_status/check (async.PollArg, async.PollEmptyResult, async.PollError)
-    "Once an async_job_id is returned from :route:`members/move_former_member_files` ,
-    use this to poll the status of the asynchronous request.
-    Permission : Team member management."
 
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/remove (MembersRemoveArg, async.LaunchEmptyResult, MembersRemoveError)
-    "Removes a member from a team.
-    Permission : Team member management
-    Exactly one of team_member_id, email, or external_id must be provided to identify the user account.
-    Accounts can be recovered via :route:`members/recover` for a 7 day period
-    or until the account has been permanently deleted or transferred to another account
-    (whichever comes first). Calling :route:`members/add` while a user is still recoverable
-    on your team will return with :field:`MemberAddResult.user_already_on_team`.
-    Accounts can have their files transferred via the admin console for a limited time, based on the version history
-    length associated with the team (180 days for most teams).
-    Accounts can have their stacks transferred through the admin console. This only transfers stacks that they have created.
-    This endpoint may initiate an asynchronous job. To obtain the final result
-    of the job, the client should periodically poll :route:`members/remove/job_status/get`."
+route properties/template/add (file_properties.AddTemplateArg, file_properties.AddTemplateResult, file_properties.ModifyTemplateError) deprecated
+    "Permission : Team member file access."
 
     attrs
         auth = "team"
-        scope = "members.delete"
+        scope = "files.team_metadata.write"
 
-route members/remove/job_status/get (async.PollArg, async.PollEmptyResult, async.PollError)
-    "Once an async_job_id is returned from :route:`members/remove` ,
-    use this to poll the status of the asynchronous request.
-    Permission : Team member management."
+route properties/template/get (file_properties.GetTemplateArg, file_properties.GetTemplateResult, file_properties.TemplateError) deprecated
+    "Permission : Team member file access. The scope for the route is files.team_metadata.write."
 
     attrs
         auth = "team"
-        scope = "members.delete"
-
-route members/set_admin_permissions (MembersSetPermissionsArg, MembersSetPermissionsResult, MembersSetPermissionsError)
-    "Updates a team member's permissions.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/set_admin_permissions:2 (MembersSetPermissions2Arg, MembersSetPermissions2Result, MembersSetPermissions2Error)
-    "Updates a team member's permissions.
-    Permission : Team member management."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/suspend (MembersDeactivateArg, Void, MembersSuspendError)
-    "Suspend a member from a team.
-    Permission : Team member management
-    Exactly one of team_member_id, email, or external_id must be provided to identify the user account."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
-
-route members/unsuspend (MembersUnsuspendArg, Void, MembersUnsuspendError)
-    "Unsuspend a member from a team.
-    Permission : Team member management
-    Exactly one of team_member_id, email, or external_id must be provided to identify the user account."
-
-    attrs
-        auth = "team"
-        scope = "members.write"
+        scope = "files.team_metadata.write"
 
 
-alias LegalHoldId = String(pattern="^pid_dbhid:.+")
+alias GroupsGetInfoResult = List(GroupsGetInfoItem)
 
-alias LegalHoldPolicyName = String(max_length=140)
-
-alias LegalHoldPolicyDescription = String(max_length=501)
-
-alias Path = String(pattern="(/(.|[\\r\\n])*)?")
-
-alias LegalHoldsPolicyCreateResult = LegalHoldPolicy
-
-alias LegalHoldsGetPolicyResult = LegalHoldPolicy
-
-alias ListHeldRevisionCursor = String(min_length=1)
-
-alias LegalHoldsPolicyUpdateResult = LegalHoldPolicy
-
-union LegalHoldStatus
-    active
-        "The legal hold policy is active."
-    released
-        "The legal hold policy was released."
-    activating
-        "The legal hold policy is activating."
-    updating
-        "The legal hold policy is updating."
-    exporting
-        "The legal hold policy is exporting."
-    releasing
-        "The legal hold policy is releasing."
-
-union LegalHoldsError
-    unknown_legal_hold_error
-        "There has been an unknown legal hold error."
-    insufficient_permissions
-        "You don't have permissions to perform this action."
-
-union LegalHoldsPolicyCreateError extends LegalHoldsError
-    start_date_is_later_than_end_date
-        "Start date must be earlier than end date."
-    empty_members_list
-        "The users list must have at least one user."
-    invalid_members
-        "Some members in the members list are not valid to be placed under legal hold."
-    number_of_users_on_hold_is_greater_than_hold_limitation
-        "You cannot add more than 5 users in a legal hold."
-    transient_error
-        "Temporary infrastructure failure, please retry."
-    name_must_be_unique
-        "The name provided is already in use by another legal hold."
-    team_exceeded_legal_hold_quota
-        "Team exceeded legal hold quota."
-    invalid_date
-        "The provided date is invalid."
-
-union LegalHoldsGetPolicyError extends LegalHoldsError
-    legal_hold_policy_not_found
-        "Legal hold policy does not exist for :field:`LegalHoldsGetPolicyArg.id`."
-
-union LegalHoldsListPoliciesError extends LegalHoldsError
-    transient_error
-        "Temporary infrastructure failure, please retry."
-
-union LegalHoldsListHeldRevisionsError extends LegalHoldsError
-    transient_error
-        "Temporary infrastructure failure, please retry."
-    legal_hold_still_empty
-        "The legal hold is not holding any revisions yet."
-    inactive_legal_hold
-        "Trying to list revisions for an inactive legal hold."
-
-union LegalHoldsListHeldRevisionsContinueError
-    unknown_legal_hold_error
-        "There has been an unknown legal hold error."
-    transient_error
-        "Temporary infrastructure failure, please retry."
-    reset
-        "Indicates that the cursor has been invalidated. Call
-        :route:`legal_holds/list_held_revisions_continue` again with an empty cursor to obtain a new cursor."
-
-union LegalHoldsPolicyUpdateError extends LegalHoldsError
-    transient_error
-        "Temporary infrastructure failure, please retry."
-    inactive_legal_hold
-        "Trying to release an inactive legal hold."
-    legal_hold_performing_another_operation
-        "Legal hold is currently performing another operation."
-    invalid_members
-        "Some members in the members list are not valid to be placed under legal hold."
-    number_of_users_on_hold_is_greater_than_hold_limitation
-        "You cannot add more than 5 users in a legal hold."
-    empty_members_list
-        "The users list must have at least one user."
-    name_must_be_unique
-        "The name provided is already in use by another legal hold."
-    legal_hold_policy_not_found
-        "Legal hold policy does not exist for :field:`LegalHoldsPolicyUpdateArg.id`."
-
-union LegalHoldsPolicyReleaseError extends LegalHoldsError
-    legal_hold_performing_another_operation
-        "Legal hold is currently performing another operation."
-    legal_hold_already_releasing
-        "Legal hold is currently performing a release or is already released."
-    legal_hold_policy_not_found
-        "Legal hold policy does not exist for :field:`LegalHoldsPolicyReleaseArg.id`."
-
-struct MembersInfo
-    team_member_ids List(team_common.TeamMemberId)
-        "Team member IDs of the users under this hold."
-    permanently_deleted_users UInt64
-        "The number of permanently deleted users that were under this hold."
+union_closed GroupAccessType
+    "Role of a user in group."
+    member
+        "User is a member of the group, but has no special permissions."
+    owner
+        "User can rename the group, and add/remove members."
 
     example default
-        team_member_ids = ["dbmid:efgh5678"]
-        permanently_deleted_users = 2
+        member = null
 
-struct LegalHoldPolicy
-    id LegalHoldId
-        "The legal hold id."
-    name LegalHoldPolicyName
-        "Policy name."
-    description LegalHoldPolicyDescription?
-        "A description of the legal hold policy."
-    activation_time common.DropboxTimestamp?
-        "The time at which the legal hold was activated."
-    members MembersInfo
-        "Team members IDs and number of permanently deleted members under hold."
-    status LegalHoldStatus
-        "The current state of the hold."
-    start_date common.DropboxTimestamp
-        "Start date of the legal hold policy."
-    end_date common.DropboxTimestamp?
-        "End date of the legal hold policy."
+union_closed GroupSelector
+    "Argument for selecting a single group, either by group_id or by external group ID."
+    group_id team_common.GroupId
+        "Group ID."
+    group_external_id team_common.GroupExternalId
+        "External ID of the group."
 
     example default
-        id = "pid_dbhid:abcd1234"
-        name = "acme cfo policy"
-        activation_time = "2016-01-20T00:00:10Z"
-        members = default
-        status = active
-        start_date = "2016-01-01T00:00:00Z"
-        end_date = "2017-12-31T00:00:00Z"
+        group_id = "g:e2db7665347abcd600000000001a2b3c"
 
-struct LegalHoldsPolicyCreateArg
-    name LegalHoldPolicyName
-        "Policy name."
-    description LegalHoldPolicyDescription?
-        "A description of the legal hold policy."
-    members List(team_common.TeamMemberId)
-        "List of team member IDs added to the hold."
-    start_date common.DropboxTimestamp?
-        "start date of the legal hold policy."
-    end_date common.DropboxTimestamp?
-        "end date of the legal hold policy."
+union GroupSelectorError
+    "Error that can be raised when :type:`GroupSelector` is used."
+    group_not_found
+        "No matching group found. No groups match the specified group ID."
 
-    example default
-        name = "acme cfo policy"
-        members = ["dbmid:FDFSVF-DFSDF"]
-        start_date = "2016-01-01T00:00:00Z"
-        end_date = "2017-12-31T00:00:00Z"
+union GroupSelectorWithTeamGroupError extends GroupSelectorError
+    "Error that can be raised when :type:`GroupSelector` is used and team groups are disallowed from
+    being used."
+    system_managed_group_disallowed
+        "This operation is not supported on system-managed groups."
 
-struct LegalHoldsGetPolicyArg
-    id LegalHoldId
-        "The legal hold Id."
+union_closed GroupsSelector
+    "Argument for selecting a list of groups, either by group_ids, or external group IDs."
+    group_ids List(team_common.GroupId)
+        "List of group IDs."
+    group_external_ids List(String)
+        "List of external IDs of groups."
 
     example default
-        id = "pid_dbhid:abcd1234"
+        group_ids = ["g:e2db7665347abcd600000000001a2b3c", "g:111111147abcd6000000000222222c"]
 
-struct LegalHoldsListPoliciesArg
-    include_released Boolean = false
-        "Whether to return holds that were released."
+union GroupMemberSelectorError extends GroupSelectorWithTeamGroupError
+    "Error that can be raised when :type:`GroupMemberSelector` is used, and the user
+    is required to be a member of the specified group."
+    member_not_in_group
+        "The specified user is not a member of this group."
 
-    example default
-        include_released = false
+union GroupMembersSelectorError extends GroupSelectorWithTeamGroupError
+    "Error that can be raised when :type:`GroupMembersSelector` is used, and the users
+    are required to be members of the specified group."
+    member_not_in_group
+        "At least one of the specified users is not a member of the group."
 
-struct LegalHoldsListPoliciesResult
-    policies List(LegalHoldPolicy)
+union GroupsListContinueError
+    invalid_cursor
+        "The cursor is invalid."
 
-    example default
-        policies = [default]
-
-struct LegalHoldsListHeldRevisionsArg
-    id LegalHoldId
-        "The legal hold Id."
-
-    example default
-        id = "pid_dbhid:abcd1234"
-
-struct LegalHoldHeldRevisionMetadata
-    new_filename String
-        "The held revision filename."
-    original_revision_id files.Rev
-        "The id of the held revision."
-    original_file_path Path
-        "The original path of the held revision."
-    server_modified common.DropboxTimestamp
-        "The last time the file was modified on Dropbox."
-    author_member_id team_common.TeamMemberId
-        "The member id of the revision's author."
-    author_member_status TeamMemberStatus
-        "The member status of the revision's author."
-    author_email common.EmailAddress
-        "The email address of the held revision author."
-    file_type String
-        "The type of the held revision's file."
-    size UInt64
-        "The file size in bytes."
-    content_hash files.Sha256HexHash
-        "A hash of the file content. This field can be used to verify data integrity. For more
-        information see our :link:`Content hash https://www.dropbox.com/developers/reference/content-hash` page."
+union_closed GroupsGetInfoItem
+    id_not_found String = ""
+        "An ID that was provided as a parameter to :route:`groups/get_info`, and
+        did not match a corresponding group. The ID can be a group ID, or an external ID,
+        depending on how the method was called."
+    group_info GroupFullInfo
+        "Info about a group."
 
     example default
-        new_filename = "111_222.pdf"
-        original_revision_id = "ab2rij4i5ojgfd"
-        original_file_path = "/a.pdf"
-        server_modified = "2019-08-12T12:08:52Z"
-        author_member_id = "dbmid:abcd1234abcd1234abcd1234abcd1234a23"
-        author_member_status = active
-        author_email = "a@a.com"
-        file_type = "Document"
-        size = 3
-        content_hash = "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234"
+        group_info = default
 
-struct LegalHoldsListHeldRevisionResult
-    entries List(LegalHoldHeldRevisionMetadata)
-        "List of file entries that under the hold."
-    cursor ListHeldRevisionCursor?
-        "The cursor idicates where to continue reading file metadata entries for the next API call. When there are no more entries, the cursor will return none.
-        Pass the cursor into
-        /2/team/legal_holds/list_held_revisions/continue."
+union GroupsGetInfoError
+    group_not_on_team
+        "The group is not on your team."
+
+union GroupCreateError
+    group_name_already_used
+        "The requested group name is already being used by another group."
+    group_name_invalid
+        "Group name is empty or has invalid characters."
+    external_id_already_in_use
+        "The requested external ID is already being used by another group."
+    system_managed_group_disallowed
+        "System-managed group cannot be manually created."
+
+union GroupDeleteError extends GroupSelectorWithTeamGroupError
+    group_already_deleted
+        "This group has already been deleted."
+
+union GroupUpdateError extends GroupSelectorWithTeamGroupError
+    group_name_already_used
+        "The requested group name is already being used by another group."
+    group_name_invalid
+        "Group name is empty or has invalid characters."
+    external_id_already_in_use
+        "The requested external ID is already being used by another group."
+
+union GroupMembersAddError extends GroupSelectorWithTeamGroupError
+    duplicate_user
+        "You cannot add duplicate users. One or more of the members
+        you are trying to add is already a member of the group."
+    group_not_in_team
+        "Group is not in this team. You cannot add members to a
+        group that is outside of your team."
+    members_not_in_team List(String)
+        "These members are not part of your team. Currently, you cannot add members
+        to a group if they are not part of your team, though this
+        may change in a subsequent version. To add new members to your Dropbox
+        Business team, use the :route:`members/add` endpoint."
+    users_not_found List(String)
+        "These users were not found in Dropbox."
+    user_must_be_active_to_be_owner
+        "A suspended user cannot be added to a group as :field:`GroupAccessType.owner`."
+    user_cannot_be_manager_of_company_managed_group List(String)
+        "A company-managed group cannot be managed by a user."
+
+union GroupMembersRemoveError extends GroupMembersSelectorError
+    group_not_in_team
+        "Group is not in this team. You cannot remove members from a group
+        that is outside of your team."
+    members_not_in_team List(String)
+        "These members are not part of your team."
+    users_not_found List(String)
+        "These users were not found in Dropbox."
+
+union GroupMemberSetAccessTypeError extends GroupMemberSelectorError
+    user_cannot_be_manager_of_company_managed_group
+        "A company managed group cannot be managed by a user."
+
+union GroupsMembersListContinueError
+    invalid_cursor
+        "The cursor is invalid."
+
+union GroupsPollError extends async.PollError
+    access_denied
+        "You are not allowed to poll this job."
+
+struct GroupMemberSelector
+    "Argument for selecting a group and a single user."
+    group GroupSelector
+        "Specify a group."
+    user UserSelectorArg
+        "Identity of a user that is a member of :field:`group`."
+
+    example default
+        group = default
+        user = default
+
+struct GroupMembersSelector
+    "Argument for selecting a group and a list of users."
+    group GroupSelector
+        "Specify a group."
+    users UsersSelectorArg
+        "A list of users that are members of :field:`group`."
+
+struct IncludeMembersArg
+    return_members Boolean = true
+        "Whether to return the list of members in the group.
+        Note that the default value will cause all the group members
+        to be returned in the response. This may take a long time for large groups."
+
+struct GroupMemberInfo
+    "Profile of group member, and role in group."
+    profile MemberProfile
+        "Profile of group member."
+    access_type GroupAccessType
+        "The role that the user has in the group."
+
+    example default
+        profile = default
+        access_type = default
+
+struct GroupFullInfo extends team_common.GroupSummary
+    "Full description of a group."
+    members List(GroupMemberInfo)?
+        "List of group members."
+    created UInt64
+        "The group creation time as a UTC timestamp in milliseconds since the Unix epoch."
+
+    example default
+        group_name = "project launch"
+        group_id = "g:e2db7665347abcd600000000001a2b3c"
+        member_count = 5
+        group_management_type = user_managed
+        members = [default]
+        created = 1447255518000
+
+struct GroupsListArg
+    limit UInt32(max_value=1000, min_value=1) = 1000
+        "Number of results to return per call."
+
+    example default
+        limit = 100
+
+struct GroupsListResult
+    groups List(team_common.GroupSummary)
+    cursor String
+        "Pass the cursor into :route:`groups/list/continue` to obtain the additional groups."
     has_more Boolean
-        "True if there are more file entries that haven't been returned. You can retrieve them with a call to /legal_holds/list_held_revisions_continue."
+        "Is true if there are additional groups that have not been returned
+        yet. An additional call to :route:`groups/list/continue` can retrieve them."
 
     example default
-        entries = [default]
+        groups = [default]
+        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
         has_more = false
 
-struct LegalHoldsListHeldRevisionsContinueArg
-    id LegalHoldId
-        "The legal hold Id."
-    cursor ListHeldRevisionCursor?
-        "The cursor idicates where to continue reading file metadata entries for the next API call. When there are no more entries, the cursor will return none."
+struct GroupsListContinueArg
+    cursor String
+        "Indicates from what point to get the next set of groups."
 
     example default
-        id = "pid_dbhid:abcd1234"
+        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
 
-struct LegalHoldsPolicyUpdateArg
-    id LegalHoldId
-        "The legal hold Id."
-    name LegalHoldPolicyName?
-        "Policy new name."
-    description LegalHoldPolicyDescription?
-        "Policy new description."
-    members List(team_common.TeamMemberId)?
-        "List of team member IDs to apply the policy on."
-
-    example default
-        id = "pid_dbhid:abcd1234"
-        members = ["dbmid:FDFSVF-DFSDF"]
-
-struct LegalHoldsPolicyReleaseArg
-    id LegalHoldId
-        "The legal hold Id."
+struct GroupCreateArg
+    group_name String
+        "Group name."
+    add_creator_as_owner Boolean = false
+        "Automatically add the creator of the group."
+    group_external_id team_common.GroupExternalId?
+        "The creator of a team can associate an arbitrary external ID to the group."
+    group_management_type team_common.GroupManagementType?
+        "Whether the team can be managed by selected users, or only by team admins."
 
     example default
-        id = "pid_dbhid:abcd1234"
+        group_name = "Europe sales"
+        group_external_id = "group-134"
 
-route legal_holds/create_policy (LegalHoldsPolicyCreateArg, LegalHoldsPolicyCreateResult, LegalHoldsPolicyCreateError)
-    "Creates new legal hold policy.
-    Note: Legal Holds is a paid add-on. Not all teams have the feature.
-    Permission : Team member file access."
-
-    attrs
-        auth = "team"
-        scope = "team_data.governance.write"
-
-route legal_holds/get_policy (LegalHoldsGetPolicyArg, LegalHoldsGetPolicyResult, LegalHoldsGetPolicyError)
-    "Gets a legal hold by Id.
-    Note: Legal Holds is a paid add-on. Not all teams have the feature.
-    Permission : Team member file access."
-
-    attrs
-        auth = "team"
-        scope = "team_data.governance.write"
-
-route legal_holds/list_policies (LegalHoldsListPoliciesArg, LegalHoldsListPoliciesResult, LegalHoldsListPoliciesError)
-    "Lists legal holds on a team.
-    Note: Legal Holds is a paid add-on. Not all teams have the feature.
-    Permission : Team member file access."
-
-    attrs
-        auth = "team"
-        scope = "team_data.governance.write"
-
-route legal_holds/list_held_revisions (LegalHoldsListHeldRevisionsArg, LegalHoldsListHeldRevisionResult, LegalHoldsListHeldRevisionsError)
-    "List the file metadata that's under the hold.
-    Note: Legal Holds is a paid add-on. Not all teams have the feature.
-    Permission : Team member file access."
-
-    attrs
-        auth = "team"
-        scope = "team_data.governance.write"
-
-route legal_holds/list_held_revisions_continue (LegalHoldsListHeldRevisionsContinueArg, LegalHoldsListHeldRevisionResult, LegalHoldsListHeldRevisionsError)
-    "Continue listing the file metadata that's under the hold.
-    Note: Legal Holds is a paid add-on. Not all teams have the feature.
-    Permission : Team member file access."
-
-    attrs
-        auth = "team"
-        scope = "team_data.governance.write"
-
-route legal_holds/update_policy (LegalHoldsPolicyUpdateArg, LegalHoldsPolicyUpdateResult, LegalHoldsPolicyUpdateError)
-    "Updates a legal hold.
-    Note: Legal Holds is a paid add-on. Not all teams have the feature.
-    Permission : Team member file access."
-
-    attrs
-        auth = "team"
-        scope = "team_data.governance.write"
-
-route legal_holds/release_policy (LegalHoldsPolicyReleaseArg, Void, LegalHoldsPolicyReleaseError)
-    "Releases a legal hold by Id.
-    Note: Legal Holds is a paid add-on. Not all teams have the feature.
-    Permission : Team member file access."
-
-    attrs
-        auth = "team"
-        scope = "team_data.governance.write"
-
-
-union_closed TeamMembershipType
-    full
-        "User uses a license and has full access to team resources like the shared quota."
-    limited
-        "User does not have access to the shared quota and team admins have restricted administrative control."
-
-struct RemovedStatus
-    is_recoverable Boolean
-        "True if the removed team member is recoverable."
-    is_disconnected Boolean
-        "True if the team member's account was converted to individual account."
+struct GroupUpdateArgs extends IncludeMembersArg
+    group GroupSelector
+        "Specify a group."
+    new_group_name String?
+        "Optional argument. Set group name to this if provided."
+    new_group_external_id team_common.GroupExternalId?
+        "Optional argument. New group external ID.
+        If the argument is None, the group's external_id won't be updated.
+        If the argument is empty string, the group's external id will be cleared."
+    new_group_management_type team_common.GroupManagementType?
+        "Set new group management type, if provided."
 
     example default
-        is_recoverable = false
-        is_disconnected = false
+        group = default
+        new_group_name = "Europe west sales"
+        new_group_external_id = "sales-234"
+        new_group_management_type = company_managed
 
-union_closed TeamMemberStatus
-    "The user's status as a member of a specific team."
-    active
-        "User has successfully joined the team."
-    invited
-        "User has been invited to a team, but has not joined the team yet."
-    suspended
-        "User is no longer a member of the team, but the account can be un-suspended,
-        re-establishing the user as a team member."
-    removed RemovedStatus
-        "User is no longer a member of the team.
-        Removed users are only listed when include_removed is true in members/list."
-
-struct MemberProfile
-    "Basic member profile."
-    team_member_id team_common.TeamMemberId
-        "ID of user as a member of a team."
-    external_id String?
-        "External ID that a team can attach to the user.
-        An application using the API may find it easier to use their
-        own IDs instead of Dropbox IDs like account_id or team_member_id."
-    account_id users_common.AccountId?
-        "A user's account identifier."
-    email String
-        "Email address of user."
-    email_verified Boolean
-        "Is true if the user's email is verified to be owned by the user."
-    secondary_emails List(secondary_emails.SecondaryEmail)?
-        "Secondary emails of a user."
-    status TeamMemberStatus
-        "The user's status as a member of a specific team."
-    name users.Name
-        "Representations for a person's name."
-    membership_type TeamMembershipType
-        "The user's membership type: full (normal team member) vs limited (does not use a license; no access to the team's shared quota)."
-    invited_on common.DropboxTimestamp?
-        "The date and time the user was invited to the team (contains value only when the member's status matches :field:`TeamMemberStatus.invited`)."
-    joined_on common.DropboxTimestamp?
-        "The date and time the user joined as a member of a specific team."
-    suspended_on common.DropboxTimestamp?
-        "The date and time the user was suspended from the team (contains value only when the member's status matches :field:`TeamMemberStatus.suspended`)."
-    persistent_id String?
-        "Persistent ID that a team can attach to the user.
-        The persistent ID is unique ID to be used for SAML authentication."
-    is_directory_restricted Boolean?
-        "Whether the user is a directory restricted user."
-    profile_photo_url String?
-        "URL for the photo representing the user, if one is set."
+struct GroupMembersChangeResult
+    "Result returned by :route:`groups/members/add` and :route:`groups/members/remove`."
+    group_info GroupFullInfo
+        "The group info after member change operation has been performed."
+    async_job_id async.AsyncJobId
+        @common.Deprecated
+        "For legacy purposes async_job_id will always return one space ' '. Formerly, it was an ID that was used to obtain the status of granting/revoking group-owned resources. It's no longer necessary because the async processing now happens automatically."
 
     example default
+        group_info = default
+        async_job_id = "99988877733388"
+
+struct MemberAccess
+    "Specify access type a member should have when joined to a group."
+    user UserSelectorArg
+        "Identity of a user."
+    access_type GroupAccessType
+        "Access type."
+
+    example default
+        user = default
+        access_type = default
+
+struct GroupMembersAddArg extends IncludeMembersArg
+    group GroupSelector
+        "Group to which users will be added."
+    members List(MemberAccess)
+        "List of users to be added to the group."
+
+    example default
+        group = default
+        members = [default]
+
+struct GroupMembersRemoveArg extends IncludeMembersArg
+    group GroupSelector
+        "Group from which users will be removed."
+    users List(UserSelectorArg)
+        "List of users to be removed from the group."
+
+    example default
+        group = default
+        users = [default]
+
+struct GroupMembersSetAccessTypeArg extends GroupMemberSelector
+    access_type GroupAccessType
+        "New group access type the user will have."
+    return_members Boolean = true
+        "Whether to return the list of members in the group.
+        Note that the default value will cause all the group members
+        to be returned in the response. This may take a long time for large groups."
+
+    example default
+        group = default
+        user = default
+        access_type = default
+
+struct GroupsMembersListArg
+    group GroupSelector
+        "The group whose members are to be listed."
+    limit UInt32(max_value=1000, min_value=1) = 1000
+        "Number of results to return per call."
+
+    example default
+        group = default
+        limit = 100
+
+struct GroupsMembersListResult
+    members List(GroupMemberInfo)
+    cursor String
+        "Pass the cursor into :route:`groups/members/list/continue` to obtain additional group members."
+    has_more Boolean
+        "Is true if there are additional group members that have not been returned
+        yet. An additional call to :route:`groups/members/list/continue` can retrieve them."
+
+    example default
+        members = []
+        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
+        has_more = false
+
+struct GroupsMembersListContinueArg
+    cursor String
+        "Indicates from what point to get the next set of groups."
+
+    example default
+        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
+
+route groups/list (GroupsListArg, GroupsListResult, Void)
+    "Lists groups on a team.
+    Permission : Team Information."
+
+    attrs
+        auth = "team"
+        scope = "groups.read"
+
+route groups/list/continue (GroupsListContinueArg, GroupsListResult, GroupsListContinueError)
+    "Once a cursor has been retrieved from :route:`groups/list`, use this to paginate
+    through all groups.
+    Permission : Team Information."
+
+    attrs
+        auth = "team"
+        scope = "groups.read"
+
+route groups/get_info (GroupsSelector, GroupsGetInfoResult, GroupsGetInfoError)
+    "Retrieves information about one or more groups. Note that the optional field
+    :field:`GroupFullInfo.members` is not returned for system-managed groups.
+    Permission : Team Information."
+
+    attrs
+        auth = "team"
+        scope = "groups.read"
+
+route groups/create (GroupCreateArg, GroupFullInfo, GroupCreateError)
+    "Creates a new, empty group, with a requested name.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "groups.write"
+
+route groups/delete (GroupSelector, async.LaunchEmptyResult, GroupDeleteError)
+    "Deletes a group.
+    The group is deleted immediately. However the revoking of group-owned resources
+    may take additional time.
+    Use the :route:`groups/job_status/get` to determine whether this process has completed.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "groups.write"
+
+route groups/update (GroupUpdateArgs, GroupFullInfo, GroupUpdateError)
+    "Updates a group's name and/or external ID.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "groups.write"
+
+route groups/members/add (GroupMembersAddArg, GroupMembersChangeResult, GroupMembersAddError)
+    "Adds members to a group.
+    The members are added immediately. However the granting of group-owned resources
+    may take additional time.
+    Use the :route:`groups/job_status/get` to determine whether this process has completed.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "groups.write"
+
+route groups/members/remove (GroupMembersRemoveArg, GroupMembersChangeResult, GroupMembersRemoveError)
+    "Removes members from a group.
+    The members are removed immediately. However the revoking of group-owned resources
+    may take additional time.
+    Use the :route:`groups/job_status/get` to determine whether this process has completed.
+    This method permits removing the only owner of a group, even in cases where this is not
+    possible via the web client.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "groups.write"
+
+route groups/members/set_access_type (GroupMembersSetAccessTypeArg, GroupsGetInfoResult, GroupMemberSetAccessTypeError)
+    "Sets a member's access type in a group.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "groups.write"
+
+route groups/members/list (GroupsMembersListArg, GroupsMembersListResult, GroupSelectorError)
+    "Lists members of a group.
+    Permission : Team Information."
+
+    attrs
+        auth = "team"
+        scope = "groups.read"
+
+route groups/members/list/continue (GroupsMembersListContinueArg, GroupsMembersListResult, GroupsMembersListContinueError)
+    "Once a cursor has been retrieved from :route:`groups/members/list`, use this to paginate
+    through all members of the group.
+    Permission : Team information."
+
+    attrs
+        auth = "team"
+        scope = "groups.read"
+
+route groups/job_status/get (async.PollArg, async.PollEmptyResult, GroupsPollError)
+    "Once an async_job_id is returned from :route:`groups/delete`,
+    :route:`groups/members/add` , or :route:`groups/members/remove`
+    use this method to poll the status of granting/revoking
+    group members' access to group-owned resources.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "groups.write"
+
+
+union ListMemberAppsError
+    "Error returned by :route:`linked_apps/list_member_linked_apps`."
+    member_not_found
+        "Member not found."
+
+union ListMembersAppsError
+    "Error returned by :route:`linked_apps/list_members_linked_apps`."
+    reset
+        "Indicates that the cursor has been invalidated. Call
+        :route:`linked_apps/list_members_linked_apps` again with an empty cursor to obtain a new cursor."
+
+union RevokeLinkedAppError
+    "Error returned by :route:`linked_apps/revoke_linked_app`."
+    app_not_found
+        "Application not found."
+    member_not_found
+        "Member not found."
+    app_folder_removal_not_supported
+        "App folder removal is not supported."
+
+union RevokeLinkedAppBatchError
+    "Error returned by :route:`linked_apps/revoke_linked_app_batch`."
+
+union ListTeamAppsError
+    "Error returned by :route:`linked_apps/list_team_linked_apps`."
+    reset
+        "Indicates that the cursor has been invalidated. Call
+        :route:`linked_apps/list_team_linked_apps` again with an empty cursor to obtain a new cursor."
+
+struct ListMemberAppsArg
+    team_member_id String
+        "The team member id."
+
+    example default
+        team_member_id = "dbmid:AAFdgehTzw7WlXhZJsbGCLePe8RvQGYDr-I"
+
+struct ApiApp
+    "Information on linked third party applications."
+    app_id String
+        "The application unique id."
+    app_name String
+        "The application name."
+    publisher String?
+        "The application publisher name."
+    publisher_url String?
+        "The publisher's URL."
+    linked common.DropboxTimestamp?
+        "The time this application was linked."
+    is_app_folder Boolean
+        "Whether the linked application uses a dedicated folder."
+
+    example default
+        app_id = "dbaid:AAFdgehTzw7WlXhZJsbGCLePe8RvQGYDr-I"
+        app_name = "Notes"
+        publisher = "Notes company"
+        publisher_url = "http://company.com"
+        linked = "2015-05-12T15:50:38Z"
+        is_app_folder = true
+
+struct ListMemberAppsResult
+    linked_api_apps List(ApiApp)
+        "List of third party applications linked by this team member."
+
+    example default
+        linked_api_apps = [default]
+
+struct ListMembersAppsArg
+    "Arguments for :route:`linked_apps/list_members_linked_apps`."
+    cursor String?
+        "At the first call to the :route:`linked_apps/list_members_linked_apps` the cursor shouldn't be
+        passed. Then, if the result of the call includes a cursor, the following requests should
+        include the received cursors in order to receive the next sub list of the team applications."
+
+    example default
+        cursor = "AADAQO8ZWKvBkSMXb1J9dAYVvwZ0wcvfyzIBo2e1H-_N-67pfrYKTb4oN_3LG9_ilWjblZXuiR8ubjjiQQkHq-MvDjbe_6bkcJgjnTpowrRaQA"
+
+struct MemberLinkedApps
+    "Information on linked applications of a team member."
+    team_member_id String
+        "The member unique Id."
+    linked_api_apps List(ApiApp)
+        "List of third party applications linked by this team member."
+
+    example default
+        team_member_id = "dbmid:AAFdgehTzw7WlXhZJsbGCLePe8RvQGYDr-I"
+        linked_api_apps = [default]
+
+struct ListMembersAppsResult
+    "Information returned by :route:`linked_apps/list_members_linked_apps`."
+    apps List(MemberLinkedApps)
+        "The linked applications of each member of the team."
+    has_more Boolean
+        "If true, then there are more apps available. Pass the
+        cursor to :route:`linked_apps/list_members_linked_apps` to retrieve the rest."
+    cursor String?
+        "Pass the cursor into :route:`linked_apps/list_members_linked_apps` to receive the next
+        sub list of team's applications."
+
+    example default
+        apps = [default]
+        has_more = true
+        cursor = "AADAQO8ZWKvBkSMXb1J9dAYVvwZ0wcvfyzIBo2e1H-_N-67pfrYKTb4oN_3LG9_ilWjblZXuiR8ubjjiQQkHq-MvDjbe_6bkcJgjnTpowrRaQA"
+
+struct RevokeLinkedApiAppArg
+    app_id String
+        "The application's unique id."
+    team_member_id String
+        "The unique id of the member owning the device."
+    keep_app_folder Boolean = true
+        @common.Deprecated
+        "This flag is not longer supported, the application dedicated folder (in case the application uses
+        one) will be kept."
+
+    example default
+        app_id = "dbaid:AAFdgehTzw7WlXhZJsbGCLePe8RvQGYDr-I"
+        team_member_id = "dbmid:AAFdgehTzw7WlXhZJsbGCLePe8RvQGYDr-I"
+
+struct RevokeLinkedApiAppBatchArg
+    revoke_linked_app List(RevokeLinkedApiAppArg)
+
+    example default
+        revoke_linked_app = [default]
+
+struct RevokeLinkedAppStatus
+    success Boolean
+        "Result of the revoking request."
+    error_type RevokeLinkedAppError?
+        "The error cause in case of a failure."
+
+    example default
+        success = false
+        error_type = app_not_found
+
+struct RevokeLinkedAppBatchResult
+    revoke_linked_app_status List(RevokeLinkedAppStatus)
+
+    example default
+        revoke_linked_app_status = [default]
+
+struct ListTeamAppsArg
+    "Arguments for :route:`linked_apps/list_team_linked_apps`."
+    cursor String?
+        "At the first call to the :route:`linked_apps/list_team_linked_apps` the cursor shouldn't be
+        passed. Then, if the result of the call includes a cursor, the following requests should
+        include the received cursors in order to receive the next sub list of the team applications."
+
+    example default
+        cursor = "AADAQO8ZWKvBkSMXb1J9dAYVvwZ0wcvfyzIBo2e1H-_N-67pfrYKTb4oN_3LG9_ilWjblZXuiR8ubjjiQQkHq-MvDjbe_6bkcJgjnTpowrRaQA"
+
+struct ListTeamAppsResult
+    "Information returned by :route:`linked_apps/list_team_linked_apps`."
+    apps List(MemberLinkedApps)
+        "The linked applications of each member of the team."
+    has_more Boolean
+        "If true, then there are more apps available. Pass the
+        cursor to :route:`linked_apps/list_team_linked_apps` to retrieve the rest."
+    cursor String?
+        "Pass the cursor into :route:`linked_apps/list_team_linked_apps` to receive the next
+        sub list of team's applications."
+
+    example default
+        apps = [default]
+        has_more = true
+        cursor = "AADAQO8ZWKvBkSMXb1J9dAYVvwZ0wcvfyzIBo2e1H-_N-67pfrYKTb4oN_3LG9_ilWjblZXuiR8ubjjiQQkHq-MvDjbe_6bkcJgjnTpowrRaQA"
+
+route linked_apps/list_member_linked_apps (ListMemberAppsArg, ListMemberAppsResult, ListMemberAppsError)
+    "List all linked applications of the team member.
+    Note, this endpoint does not list any team-linked applications."
+
+    attrs
+        auth = "team"
+        scope = "sessions.list"
+
+route linked_apps/list_members_linked_apps (ListMembersAppsArg, ListMembersAppsResult, ListMembersAppsError)
+    "List all applications linked to the team members' accounts.
+    Note, this endpoint does not list any team-linked applications."
+
+    attrs
+        auth = "team"
+        scope = "sessions.list"
+
+route linked_apps/revoke_linked_app (RevokeLinkedApiAppArg, Void, RevokeLinkedAppError)
+    "Revoke a linked application of the team member."
+
+    attrs
+        auth = "team"
+        scope = "sessions.modify"
+
+route linked_apps/revoke_linked_app_batch (RevokeLinkedApiAppBatchArg, RevokeLinkedAppBatchResult, RevokeLinkedAppBatchError)
+    "Revoke a list of linked applications of the team members."
+
+    attrs
+        auth = "team"
+        scope = "sessions.modify"
+
+route linked_apps/list_team_linked_apps (ListTeamAppsArg, ListTeamAppsResult, ListTeamAppsError) deprecated
+    "List all applications linked to the team members' accounts.
+    Note, this endpoint doesn't list any team-linked applications."
+
+    attrs
+        auth = "team"
+        scope = "sessions.list"
+
+
+alias UserQuota = UInt32(min_value=2)
+
+struct UserCustomQuotaArg
+    "User and their required custom quota in GB (1 TB = 1024 GB)."
+    user UserSelectorArg
+    quota_gb UserQuota
+
+    example default
+        user = default
+        quota_gb = 30
+
+struct UserCustomQuotaResult
+    "User and their custom quota in GB (1 TB = 1024 GB).
+    No quota returns if the user has no custom quota set."
+    user UserSelectorArg
+    quota_gb UserQuota?
+
+struct SetCustomQuotaArg
+    users_and_quotas List(UserCustomQuotaArg)
+        "List of users and their custom quotas."
+
+    example default
+        users_and_quotas = [default]
+
+union CustomQuotaError
+    "Error returned when getting member custom quota."
+    too_many_users
+        "A maximum of 1000 users can be set for a single call."
+
+union SetCustomQuotaError extends CustomQuotaError
+    "Error returned when setting member custom quota."
+    some_users_are_excluded
+        "Some of the users are on the excluded users list and can't have custom quota set."
+
+union CustomQuotaResult
+    "User custom quota."
+    success UserCustomQuotaResult
+        "User's custom quota."
+    invalid_user UserSelectorArg
+        "Invalid user (not in team)."
+
+struct CustomQuotaUsersArg
+    users List(UserSelectorArg)
+        "List of users."
+
+    example default
+        users = [default]
+
+union RemoveCustomQuotaResult
+    "User result for setting member custom quota."
+    success UserSelectorArg
+        "Successfully removed user."
+    invalid_user UserSelectorArg
+        "Invalid user (not in team)."
+
+struct ExcludedUsersUpdateArg
+    "Argument of excluded users update operation.
+    Should include a list of users to add/remove (according to endpoint),
+    Maximum size of the list is 1000 users."
+    users List(UserSelectorArg)?
+        "List of users to be added/removed."
+
+    example default
+        users = [default]
+
+union ExcludedUsersUpdateError
+    "Excluded users update error."
+    users_not_in_team
+        "At least one of the users is not part of your team."
+    too_many_users
+        "A maximum of 1000 users for each of addition/removal can be supplied."
+
+struct ExcludedUsersListArg
+    "Excluded users list argument."
+    limit UInt32(max_value=1000, min_value=1) = 1000
+        "Number of results to return per call."
+
+    example default
+        limit = 100
+
+struct ExcludedUsersListContinueArg
+    "Excluded users list continue argument."
+    cursor String
+        "Indicates from what point to get the next set of users."
+
+    example default
+        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
+
+struct ExcludedUsersListResult
+    "Excluded users list result."
+    users List(MemberProfile)
+    cursor String?
+        "Pass the cursor into :route:`member_space_limits/excluded_users/list/continue` to obtain
+        additional excluded users."
+    has_more Boolean
+        "Is true if there are additional excluded users that have not been returned
+        yet. An additional call to :route:`member_space_limits/excluded_users/list/continue` can
+        retrieve them."
+
+    example default
+        users = []
+        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
+        has_more = false
+
+union ExcludedUsersUpdateStatus
+    "Excluded users update operation status."
+    success
+        "Update successful."
+
+struct ExcludedUsersUpdateResult
+    "Excluded users update result."
+    status ExcludedUsersUpdateStatus
+        "Update status."
+
+    example default
+        status = success
+
+union ExcludedUsersListError
+    "Excluded users list error."
+    list_error
+        "An error occurred."
+
+union ExcludedUsersListContinueError
+    "Excluded users list continue error."
+    invalid_cursor
+        "The cursor is invalid."
+
+route member_space_limits/set_custom_quota (SetCustomQuotaArg, List(CustomQuotaResult), SetCustomQuotaError)
+    "Set users custom quota. Custom quota has to be at least 2GB.
+    A maximum of 1000 members can be specified in a single call.
+    Note: to apply a custom space limit, a team admin needs to set a member space limit for the team first.
+    (the team admin can check the settings here: https://www.dropbox.com/team/admin/settings/space)."
+
+    attrs
+        auth = "team"
+        scope = "members.read"
+
+route member_space_limits/remove_custom_quota (CustomQuotaUsersArg, List(RemoveCustomQuotaResult), CustomQuotaError)
+    "Remove users custom quota.
+    A maximum of 1000 members can be specified in a single call.
+    Note: to apply a custom space limit, a team admin needs to set a member space limit for the team first.
+    (the team admin can check the settings here: https://www.dropbox.com/team/admin/settings/space)."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route member_space_limits/get_custom_quota (CustomQuotaUsersArg, List(CustomQuotaResult), CustomQuotaError)
+    "Get users custom quota.
+    A maximum of 1000 members can be specified in a single call.
+    Note: to apply a custom space limit, a team admin needs to set a member space limit for the team first.
+    (the team admin can check the settings here: https://www.dropbox.com/team/admin/settings/space)."
+
+    attrs
+        auth = "team"
+        scope = "members.read"
+
+route member_space_limits/excluded_users/add (ExcludedUsersUpdateArg, ExcludedUsersUpdateResult, ExcludedUsersUpdateError)
+    "Add users to member space limits excluded users list."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route member_space_limits/excluded_users/remove (ExcludedUsersUpdateArg, ExcludedUsersUpdateResult, ExcludedUsersUpdateError)
+    "Remove users from member space limits excluded users list."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route member_space_limits/excluded_users/list (ExcludedUsersListArg, ExcludedUsersListResult, ExcludedUsersListError)
+    "List member space limits excluded users."
+
+    attrs
+        auth = "team"
+        scope = "members.read"
+
+route member_space_limits/excluded_users/list/continue (ExcludedUsersListContinueArg, ExcludedUsersListResult, ExcludedUsersListContinueError)
+    "Continue listing member space limits excluded users."
+
+    attrs
+        auth = "team"
+        scope = "members.read"
+
+
+union AddSecondaryEmailResult
+    "Result of trying to add a secondary email to a user.
+    'success' is the only value indicating that a secondary email was successfully added to a user.
+    The other values explain the type of error that occurred, and include the email for which the error occurred."
+    success secondary_emails.SecondaryEmail
+        "Describes a secondary email that was successfully added to a user."
+    unavailable common.EmailAddress
+        "Secondary email is not available to be claimed by the user."
+    already_pending common.EmailAddress
+        "Secondary email is already a pending email for the user."
+    already_owned_by_user common.EmailAddress
+        "Secondary email is already a verified email for the user."
+    reached_limit common.EmailAddress
+        "User already has the maximum number of secondary emails allowed."
+    transient_error common.EmailAddress
+        @common.Deprecated
+        "A transient error occurred. Please try again later."
+    too_many_updates common.EmailAddress
+        "An error occurred due to conflicting updates. Please try again later."
+    unknown_error common.EmailAddress
+        "An unknown error occurred."
+    rate_limited common.EmailAddress
+        "Too many emails are being sent to this email address. Please try again later."
+
+    example default
+        success = default
+
+    example unavailable
+        unavailable = "alice@example.com"
+
+union UserAddResult
+    "Result of trying to add secondary emails to a user.
+    'success' is the only value indicating that a user was successfully retrieved for adding secondary emails.
+    The other values explain the type of error that occurred, and include the user for which the error occurred."
+    success UserSecondaryEmailsResult
+        "Describes a user and the results for each attempt to add a secondary email."
+    invalid_user UserSelectorArg
+        "Specified user is not a valid target for adding secondary emails."
+    unverified UserSelectorArg
+        "Secondary emails can only be added to verified users."
+    placeholder_user UserSelectorArg
+        "Secondary emails cannot be added to placeholder users."
+
+    example default
+        success = default
+
+    example invalid
+        invalid_user = default
+
+union AddSecondaryEmailsError
+    "Error returned when adding secondary emails fails."
+    secondary_emails_disabled
+        "Secondary emails are disabled for the team."
+    too_many_emails
+        "A maximum of 20 secondary emails can be added in a single call."
+
+union ResendSecondaryEmailResult
+    "Result of trying to resend verification email to a secondary email address.
+    'success' is the only value indicating that a verification email was successfully sent.
+    The other values explain the type of error that occurred, and include the email for which the error occurred."
+    success common.EmailAddress
+        "A verification email was successfully sent to the secondary email address."
+    not_pending common.EmailAddress
+        "This secondary email address is not pending for the user."
+    rate_limited common.EmailAddress
+        "Too many emails are being sent to this email address. Please try again later."
+
+    example default
+        success = "alice@example.com"
+
+union UserResendResult
+    "Result of trying to resend verification emails to a user.
+    'success' is the only value indicating that a user was successfully retrieved for sending verification emails.
+    The other values explain the type of error that occurred, and include the user for which the error occurred."
+    success UserResendEmailsResult
+        "Describes a user and the results for each attempt to resend verification emails."
+    invalid_user UserSelectorArg
+        "Specified user is not a valid target for resending verification emails."
+
+    example default
+        success = default
+
+    example invalid
+        invalid_user = default
+
+union DeleteSecondaryEmailResult
+    "Result of trying to delete a secondary email address.
+    'success' is the only value indicating that a secondary email was successfully deleted.
+    The other values explain the type of error that occurred, and include the email for which the error occurred."
+    success common.EmailAddress
+        "The secondary email was successfully deleted."
+    not_found common.EmailAddress
+        "The email address was not found for the user."
+    cannot_remove_primary common.EmailAddress
+        "The email address is the primary email address of the user, and cannot be removed."
+
+    example default
+        success = "alice@example.com"
+
+    example not_found
+        not_found = "alic@example.com"
+
+union UserDeleteResult
+    "Result of trying to delete a user's secondary emails.
+    'success' is the only value indicating that a user was successfully retrieved for deleting secondary emails.
+    The other values explain the type of error that occurred, and include the user for which the error occurred."
+    success UserDeleteEmailsResult
+        "Describes a user and the results for each attempt to delete a secondary email."
+    invalid_user UserSelectorArg
+        "Specified user is not a valid target for deleting secondary emails."
+
+    example default
+        success = default
+
+    example invalid_user
+        invalid_user = default
+
+struct UserSecondaryEmailsArg
+    "User and a list of secondary emails."
+    user UserSelectorArg
+    secondary_emails List(common.EmailAddress)
+
+    example default
+        user = default
+        secondary_emails = ["bob2@hotmail.com", "bob@inst.gov"]
+
+struct UserSecondaryEmailsResult
+    user UserSelectorArg
+    results List(AddSecondaryEmailResult)
+
+    example default
+        user = default
+        results = [default, unavailable]
+
+struct AddSecondaryEmailsArg
+    new_secondary_emails List(UserSecondaryEmailsArg)
+        "List of users and secondary emails to add."
+
+    example default
+        new_secondary_emails = [default]
+
+struct AddSecondaryEmailsResult
+    results List(UserAddResult)
+        "List of users and secondary email results."
+
+    example default
+        results = [default, invalid]
+
+struct ResendVerificationEmailArg
+    emails_to_resend List(UserSecondaryEmailsArg)
+        "List of users and secondary emails to resend verification emails to."
+
+    example default
+        emails_to_resend = [default]
+
+struct UserResendEmailsResult
+    user UserSelectorArg
+    results List(ResendSecondaryEmailResult)
+
+    example default
+        user = default
+        results = [default]
+
+struct ResendVerificationEmailResult
+    "List of users and resend results."
+    results List(UserResendResult)
+
+    example default
+        results = [default]
+
+struct DeleteSecondaryEmailsArg
+    emails_to_delete List(UserSecondaryEmailsArg)
+        "List of users and their secondary emails to delete."
+
+    example default
+        emails_to_delete = [default]
+
+struct UserDeleteEmailsResult
+    user UserSelectorArg
+    results List(DeleteSecondaryEmailResult)
+
+    example default
+        user = default
+        results = [default, not_found]
+
+struct DeleteSecondaryEmailsResult
+    results List(UserDeleteResult)
+
+    example default
+        results = [default]
+
+route members/secondary_emails/add (AddSecondaryEmailsArg, AddSecondaryEmailsResult, AddSecondaryEmailsError)
+    "Add secondary emails to users.
+    Permission : Team member management.
+    Emails that are on verified domains will be verified automatically.
+    For each email address not on a verified domain a verification email will be sent."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/secondary_emails/resend_verification_emails (ResendVerificationEmailArg, ResendVerificationEmailResult, Void)
+    "Resend secondary email verification emails.
+    Permission : Team member management."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+route members/secondary_emails/delete (DeleteSecondaryEmailsArg, DeleteSecondaryEmailsResult, Void)
+    "Delete secondary emails from users
+    Permission : Team member management.
+    Users will be notified of deletions of verified secondary emails at both the secondary email and their primary email."
+
+    attrs
+        auth = "team"
+        scope = "members.write"
+
+
+union SharingAllowlistAddError
+    malformed_entry String = ""
+        "One of provided values is not valid."
+    no_entries_provided
+        "Neither single domain nor email provided."
+    too_many_entries_provided
+        "Too many entries provided within one call."
+    team_limit_reached
+        "Team entries limit reached."
+    unknown_error
+        "Unknown error."
+    entries_already_exist String = ""
+        "Entries already exists."
+
+union SharingAllowlistListContinueError
+    invalid_cursor
+        "Provided cursor is not valid."
+
+union SharingAllowlistRemoveError
+    malformed_entry String = ""
+        "One of provided values is not valid."
+    entries_do_not_exist String = ""
+        "One or more provided values do not exist."
+    no_entries_provided
+        "Neither single domain nor email provided."
+    too_many_entries_provided
+        "Too many entries provided within one call."
+    unknown_error
+        "Unknown error."
+
+struct SharingAllowlistAddArgs
+    "Structure representing Approve List entries. Domain and emails are supported.
+    At least one entry of any supported type is required."
+    domains List(String)?
+        "List of domains represented by valid string representation (RFC-1034/5)."
+    emails List(String)?
+        "List of emails represented by valid string representation (RFC-5322/822)."
+
+    example default
+        domains = ["test-domain.com", "subdomain.some.com"]
+        emails = ["adam@test-domain.com", "john@some.com"]
+
+struct SharingAllowlistAddResponse
+    "This struct is empty. The comment here is intentionally emitted to avoid indentation issues with Stone."
+
+struct SharingAllowlistListArg
+    limit UInt32(max_value=1000, min_value=1) = 1000
+        "The number of entries to fetch at one time."
+
+    example default
+        limit = 100
+
+struct SharingAllowlistListContinueArg
+    cursor String
+        "The cursor returned from a previous call to :route:`sharing_allowlist/list` or :route:`sharing_allowlist/list/continue`."
+
+    example default
+        cursor = "dGVzdF9jdXJzb3IK"
+
+struct SharingAllowlistListError
+    "This struct is empty. The comment here is intentionally emitted to avoid indentation issues with Stone."
+
+struct SharingAllowlistListResponse
+    domains List(String)
+        "List of domains represented by valid string representation (RFC-1034/5)."
+    emails List(String)
+        "List of emails represented by valid string representation (RFC-5322/822)."
+    cursor String = ""
+        "If this is nonempty, there are more entries that can be fetched with :route:`sharing_allowlist/list/continue`."
+    has_more Boolean = false
+        "if true indicates that more entries can be fetched with :route:`sharing_allowlist/list/continue`."
+
+    example default
+        domains = ["test-domain.com", "subdomain.some.com"]
+        emails = ["adam@test-domain.com", "john@some.com"]
+        cursor = "dGVzdF9jdXJzb3IK"
+        has_more = true
+
+struct SharingAllowlistRemoveArgs
+    domains List(String)?
+        "List of domains represented by valid string representation (RFC-1034/5)."
+    emails List(String)?
+        "List of emails represented by valid string representation (RFC-5322/822)."
+
+    example default
+        domains = ["test-domain.com", "subdomain.some.com"]
+        emails = ["adam@test-domain.com", "john@some.com"]
+
+struct SharingAllowlistRemoveResponse
+    "This struct is empty. The comment here is intentionally emitted to avoid indentation issues with Stone."
+
+route sharing_allowlist/add (SharingAllowlistAddArgs, SharingAllowlistAddResponse, SharingAllowlistAddError)
+    "Endpoint adds Approve List entries. Changes are effective immediately.
+    Changes are committed in transaction. In case of single validation error - all entries are rejected.
+    Valid domains (RFC-1034/5) and emails (RFC-5322/822) are accepted.
+    Added entries cannot overflow limit of 10000 entries per team.
+    Maximum 100 entries per call is allowed."
+
+    attrs
+        auth = "team"
+        is_preview = true
+        scope = "team_info.write"
+
+route sharing_allowlist/list (SharingAllowlistListArg, SharingAllowlistListResponse, SharingAllowlistListError)
+    "Lists Approve List entries for given team, from newest to oldest, returning
+    up to `limit` entries at a time. If there are more than `limit` entries
+    associated with the current team, more can be fetched by passing the
+    returned `cursor` to :route:`sharing_allowlist/list/continue`."
+
+    attrs
+        auth = "team"
+        is_preview = true
+        scope = "team_info.read"
+
+route sharing_allowlist/list/continue (SharingAllowlistListContinueArg, SharingAllowlistListResponse, SharingAllowlistListContinueError)
+    "Lists entries associated with given team, starting from a the cursor. See :route:`sharing_allowlist/list`."
+
+    attrs
+        auth = "team"
+        is_preview = true
+        scope = "team_info.read"
+
+route sharing_allowlist/remove (SharingAllowlistRemoveArgs, SharingAllowlistRemoveResponse, SharingAllowlistRemoveError)
+    "Endpoint removes Approve List entries. Changes are effective immediately.
+    Changes are committed in transaction. In case of single validation error - all entries are rejected.
+    Valid domains (RFC-1034/5) and emails (RFC-5322/822) are accepted.
+    Entries being removed have to be present on the list.
+    Maximum 1000 entries per call is allowed."
+
+    attrs
+        auth = "team"
+        is_preview = true
+        scope = "team_info.write"
+
+
+union NamespaceType
+    app_folder
+        "App sandbox folder."
+    shared_folder
+        "Shared folder."
+    team_folder
+        "Top-level team-owned folder."
+    team_member_folder
+        "Team member's home folder."
+    team_member_root
+        "Team member's root folder."
+
+union TeamNamespacesListContinueError extends TeamNamespacesListError
+    invalid_cursor
+        "The cursor is invalid."
+
+union TeamNamespacesListError
+    invalid_arg
+        "Argument passed in is invalid."
+
+struct NamespaceMetadata
+    "Properties of a namespace."
+    name String
+        "The name of this namespace."
+    namespace_id common.SharedFolderId
+        "The ID of this namespace."
+    namespace_type NamespaceType
+        "The type of this namespace."
+    team_member_id team_common.TeamMemberId?
+        "If this is a team member or app folder, the ID of the owning team member.
+        Otherwise, this field is not present."
+    quota_limit Int64 = 0
+        "The quota limit in bytes for this namespace tree. Only applicable to team folders."
+
+    example shared_folder
+        name = "Marketing"
+        namespace_id = "123456789"
+        namespace_type = shared_folder
+        quota_limit = 0
+
+    example team_member_folder
+        name = "Franz Ferdinand"
+        namespace_id = "123456789"
+        namespace_type = team_member_folder
         team_member_id = "dbmid:1234567"
-        account_id = "dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc"
-        email = "mary@lamb.com"
-        email_verified = true
-        secondary_emails = [default, second_sec_email, third_sec_email]
-        status = active
-        name = default
-        membership_type = full
-        joined_on = "2015-05-12T15:50:38Z"
-        profile_photo_url = "https://dl-web.dropbox.com/account_photo/get/dbaphid%3AAAHWGmIXV3sUuOmBfTz0wPsiqHUpBWvv3ZA?vers=1556069330102&size=128x128"
+        quota_limit = 0
 
-struct TeamMemberProfile extends MemberProfile
-    "Profile of a user as a member of a team."
-    groups List(team_common.GroupId)
-        "List of group IDs of groups that the user belongs to."
-    member_folder_id common.NamespaceId
-        "The namespace id of the user's member folder."
-    root_folder_id common.NamespaceId
-        "The namespace id of the user's root folder."
+struct TeamNamespacesListResult
+    "Result for :route:`namespaces/list`."
+    namespaces List(NamespaceMetadata)
+        "List of all namespaces the team can access."
+    cursor String
+        "Pass the cursor into :route:`namespaces/list/continue` to obtain
+        additional namespaces. Note that duplicate namespaces may be returned."
+    has_more Boolean
+        "Is true if there are additional namespaces that have not been returned yet."
 
     example default
-        team_member_id = "dbmid:FDFSVF-DFSDF"
-        account_id = "dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc"
-        external_id = "244423"
-        email = "tami@seagull.com"
-        email_verified = false
-        secondary_emails = [third_sec_email, default]
-        status = active
-        name = default
-        groups = ["g:e2db7665347abcd600000000001a2b3c"]
-        membership_type = full
-        joined_on = "2015-05-12T15:50:38Z"
-        member_folder_id = "20"
-        root_folder_id = "30"
-        profile_photo_url = "https://dl-web.dropbox.com/account_photo/get/dbaphid%3AAAHWGmIXV3sUuOmBfTz0wPsiqHUpBWvv3ZA?vers=1556069330102&size=128x128"
+        namespaces = [shared_folder, team_member_folder]
+        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
+        has_more = false
+
+struct TeamNamespacesListArg
+    limit UInt32(max_value=1000, min_value=1) = 1000
+        @common.Deprecated
+        "Specifying a value here has no effect."
+
+    example default
+        limit = 1
+
+    example with_filter
+        limit = 1
+
+struct TeamNamespacesListContinueArg
+    cursor String
+        "Indicates from what point to get the next set of team-accessible namespaces."
+
+    example default
+        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
+
+    example with_filter
+        cursor = "ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu"
+
+route namespaces/list (TeamNamespacesListArg, TeamNamespacesListResult, TeamNamespacesListError)
+    "Returns a list of all team-accessible namespaces. This list includes team folders,
+    shared folders containing team members, team members' home namespaces, and team members'
+    app folders. Home namespaces and app folders are always owned by this team or members of the
+    team, but shared folders may be owned by other users or other teams. Duplicates may occur in the
+    list."
+
+    attrs
+        auth = "team"
+        scope = "team_data.member"
+
+route namespaces/list/continue (TeamNamespacesListContinueArg, TeamNamespacesListResult, TeamNamespacesListContinueError)
+    "Once a cursor has been retrieved from :route:`namespaces/list`, use this to paginate
+    through all team-accessible namespaces. Duplicates may occur in the list."
+
+    attrs
+        auth = "team"
+        scope = "team_data.member"
+
+
+route reports/get_activity (DateRange, GetActivityReport, DateRangeError) deprecated
+    "Retrieves reporting data about a team's user activity.
+    Deprecated: Will be removed on July 1st 2021."
+
+    attrs
+        auth = "team"
+        scope = "team_info.read"
+
+
+route reports/get_storage (DateRange, GetStorageReport, DateRangeError) deprecated
+    "Retrieves reporting data about a team's storage usage.
+    Deprecated: Will be removed on July 1st 2021."
+
+    attrs
+        auth = "team"
+        scope = "team_info.read"
+
+
+route reports/get_devices (DateRange, GetDevicesReport, DateRangeError) deprecated
+    "Retrieves reporting data about a team's linked devices.
+    Deprecated: Will be removed on July 1st 2021."
+
+    attrs
+        auth = "team"
+        scope = "team_info.read"
+
+
+route reports/get_membership (DateRange, GetMembershipReport, DateRangeError) deprecated
+    "Retrieves reporting data about a team's membership.
+    Deprecated: Will be removed on July 1st 2021."
+
+    attrs
+        auth = "team"
+        scope = "team_info.read"
+
+
+alias NumberPerDay = List(UInt64?)
+
+union TeamReportFailureReason
+    temporary_error
+        "We couldn't create the report, but we think this was a fluke. Everything should work if you try it again."
+    many_reports_at_once
+        "Too many other reports are being created right now. Try creating this report again once the others finish."
+    too_much_data
+        "We couldn't create the report. Try creating the report again with less data."
+
+    example default
+        many_reports_at_once = null
+
+union DateRangeError
+    "Errors that can originate from problems in input arguments to reports."
+
+struct DateRange
+    "Input arguments that can be provided for most reports."
+    start_date common.Date?
+        "Optional starting date (inclusive). If start_date is None or too long ago, this field will
+        be set to 6 months ago."
+    end_date common.Date?
+        "Optional ending date (exclusive)."
+
+struct StorageBucket
+    "Describes the number of users in a specific storage bucket."
+    bucket String
+        "The name of the storage bucket.
+        For example, '1G' is a bucket of users with storage size up to 1 Giga."
+    users UInt64
+        "The number of people whose storage is in the range of this storage bucket."
+
+    example default
+        bucket = "1G"
+        users = 21
+
+struct BaseDfbReport
+    "Base report structure."
+    start_date String
+        "First date present in the results as 'YYYY-MM-DD' or None."
+
+struct GetStorageReport extends BaseDfbReport
+    "Storage Report Result.
+    Each of the items in the storage report is an array of values, one value per day.
+    If there is no data for a day, then the value will be None."
+    total_usage NumberPerDay
+        "Sum of the shared, unshared, and datastore usages, for each day."
+    shared_usage NumberPerDay
+        "Array of the combined size (bytes) of team members' shared folders, for each day."
+    unshared_usage NumberPerDay
+        "Array of the combined size (bytes) of team members' root namespaces, for each day."
+    shared_folders NumberPerDay
+        "Array of the number of shared folders owned by team members, for each day."
+    member_storage_map List(List(StorageBucket))
+        "Array of storage summaries of team members' account sizes.
+        Each storage summary is an array of key, value pairs, where each pair describes
+        a storage bucket.
+        The key indicates the upper bound of the bucket and the value is the
+        number of users in that bucket. There is one such summary per day.
+        If there is no data for a day, the storage summary will be empty."
+
+struct GetActivityReport extends BaseDfbReport
+    "Activity Report Result.
+    Each of the items in the storage report is an array of values, one value per day.
+    If there is no data for a day, then the value will be None."
+    adds NumberPerDay
+        "Array of total number of adds by team members."
+    edits NumberPerDay
+        "Array of number of edits by team members.
+        If the same user edits the same file multiple times this is counted as a single edit."
+    deletes NumberPerDay
+        "Array of total number of deletes by team members."
+    active_users_28_day NumberPerDay
+        "Array of the number of users who have been active in the last 28 days."
+    active_users_7_day NumberPerDay
+        "Array of the number of users who have been active in the last week."
+    active_users_1_day NumberPerDay
+        "Array of the number of users who have been active in the last day."
+    active_shared_folders_28_day NumberPerDay
+        "Array of the number of shared folders with some activity in the last 28 days."
+    active_shared_folders_7_day NumberPerDay
+        "Array of the number of shared folders with some activity in the last week."
+    active_shared_folders_1_day NumberPerDay
+        "Array of the number of shared folders with some activity in the last day."
+    shared_links_created NumberPerDay
+        "Array of the number of shared links created."
+    shared_links_viewed_by_team NumberPerDay
+        "Array of the number of views by team users to shared links created by the team."
+    shared_links_viewed_by_outside_user NumberPerDay
+        "Array of the number of views by users outside of the team to shared links created by the team."
+    shared_links_viewed_by_not_logged_in NumberPerDay
+        "Array of the number of views by non-logged-in users to shared links created by the team."
+    shared_links_viewed_total NumberPerDay
+        "Array of the total number of views to shared links created by the team."
+
+struct GetMembershipReport extends BaseDfbReport
+    "Membership Report Result.
+    Each of the items in the storage report is an array of values, one value per day.
+    If there is no data for a day, then the value will be None."
+    team_size NumberPerDay
+        "Team size, for each day."
+    pending_invites NumberPerDay
+        "The number of pending invites to the team, for each day."
+    members_joined NumberPerDay
+        "The number of members that joined the team, for each day."
+    suspended_members NumberPerDay
+        "The number of suspended team members, for each day."
+    licenses NumberPerDay
+        "The total number of licenses the team has, for each day."
+
+struct DevicesActive
+    "Each of the items is an array of values, one value per day.
+    The value is the number of devices active within a time window, ending with that day.
+    If there is no data for a day, then the value will be None."
+    windows NumberPerDay
+        "Array of number of linked windows (desktop) clients with activity."
+    macos NumberPerDay
+        "Array of number of linked mac (desktop) clients with activity."
+    linux NumberPerDay
+        "Array of number of linked linus (desktop) clients with activity."
+    ios NumberPerDay
+        "Array of number of linked ios devices with activity."
+    android NumberPerDay
+        "Array of number of linked android devices with activity."
+    other NumberPerDay
+        "Array of number of other linked devices (blackberry, windows phone, etc)
+        with activity."
+    total NumberPerDay
+        "Array of total number of linked clients with activity."
+
+struct GetDevicesReport extends BaseDfbReport
+    "Devices Report Result. Contains subsections for different time ranges of activity.
+    Each of the items in each subsection of the storage report is an array of values,
+    one value per day.
+    If there is no data for a day, then the value will be None."
+    active_1_day DevicesActive
+        "Report of the number of devices active in the last day."
+    active_7_day DevicesActive
+        "Report of the number of devices active in the last 7 days."
+    active_28_day DevicesActive
+        "Report of the number of devices active in the last 28 days."
 

--- a/team_log.stone
+++ b/team_log.stone
@@ -766,6 +766,18 @@ union TeamExtensionsPolicy
     disabled
     enabled
 
+union TeamFolderNotificationTarget
+    "Team folder space limit notification target"
+    admins
+    both
+    editors
+    silent
+
+union TeamFolderSpaceCapsType
+    "Team folder space limit enforcement type"
+    off
+    soft
+
 union TeamMemberStorageRequestPolicy
     "Policy for deciding whether team members can request increased storage limits from admins"
     default
@@ -836,7 +848,7 @@ union ActionDetails
 
     example default
         team_join_details = default
-    
+
     example default2
         team_join_details = default2
 
@@ -855,7 +867,7 @@ union AssetLogInfo
 
     example default
         file = default
-    
+
     example default2
         file = default2
 
@@ -868,7 +880,7 @@ union FedExtraDetails
 
     example default
         team = default
-    
+
     example default2
         team = default2
 
@@ -883,7 +895,7 @@ union FederationStatusChangeAdditionalInfo
 
     example default
         connected_team_name = default
-    
+
     example default2
         connected_team_name = default2
 
@@ -900,7 +912,7 @@ union LinkedDeviceLogInfo
 
     example default
         mobile_device_session = default
-    
+
     example default2
         mobile_device_session = default2
 
@@ -913,7 +925,7 @@ union ParticipantLogInfo
 
     example default
         user = default
-    
+
     example default2
         user = default2
 
@@ -926,7 +938,7 @@ union TeamMergeRequestAcceptedExtraDetails
 
     example default
         primary_team = default
-    
+
     example default2
         primary_team = default2
 
@@ -939,7 +951,7 @@ union TeamMergeRequestCanceledExtraDetails
 
     example default
         primary_team = default
-    
+
     example default2
         primary_team = default2
 
@@ -952,7 +964,7 @@ union TeamMergeRequestExpiredExtraDetails
 
     example default
         primary_team = default
-    
+
     example default2
         primary_team = default2
 
@@ -965,7 +977,7 @@ union TeamMergeRequestReminderExtraDetails
 
     example default
         primary_team = default
-    
+
     example default2
         primary_team = default2
 
@@ -978,7 +990,7 @@ union WebSessionsFixedLengthPolicy
 
     example default
         defined = default
-    
+
     example default2
         defined = default2
 
@@ -991,7 +1003,7 @@ union WebSessionsIdleLengthPolicy
 
     example default
         defined = default
-    
+
     example default2
         defined = default2
 
@@ -1002,7 +1014,7 @@ struct AddonLogInfo
 
     example default
         addon_name = "abc"
-    
+
     example default2
         addon_name = "xyz"
 
@@ -1028,7 +1040,7 @@ struct AdminAlertingAlertConfiguration
         text = "abc"
         excluded_file_extensions = "abc"
         malware_exclusion_state = default
-    
+
     example default2
         alert_state = off
         sensitivity_level = invalid
@@ -1050,7 +1062,7 @@ struct AppLogInfo
 
     example default
         team_linked_app = default
-    
+
     example default2
         team_linked_app = default2
 
@@ -1079,7 +1091,7 @@ struct Certificate
         serial_number = "abc"
         sha1_fingerprint = "abc"
         common_name = "abc"
-    
+
     example default2
         subject = "xyz"
         issuer = "xyz"
@@ -1096,7 +1108,7 @@ struct ConnectedTeamName
 
     example default
         team = "My Team"
-    
+
     example default2
         team = "My Team"
 
@@ -1125,7 +1137,7 @@ struct DesktopDeviceSessionLogInfo extends DeviceSessionLogInfo
         client_version = "abc"
         platform = "abc"
         is_delete_on_unlink_supported = true
-    
+
     example default2
         ip_address = "45.56.78.100"
         created = "2017-01-25T15:51:30Z"
@@ -1142,7 +1154,7 @@ struct DesktopSessionLogInfo extends SessionLogInfo
 
     example default
         session_id = "dbwsid:123456789012345678901234567890123456789"
-    
+
     example default2
         session_id = "dbwsid:abcd5678901234567890123456789012345abcd"
 
@@ -1162,7 +1174,7 @@ struct DeviceSessionLogInfo
 
     example default
         desktop_device_session = default
-    
+
     example default2
         desktop_device_session = default2
 
@@ -1176,7 +1188,7 @@ struct DurationLogInfo
     example default
         unit = milliseconds
         amount = 3
-    
+
     example default2
         unit = milliseconds
         amount = 4
@@ -1191,7 +1203,7 @@ struct ExternalUserLogInfo
     example default
         user_identifier = "david@example.com"
         identifier_type = email
-    
+
     example default2
         user_identifier = "david@example.com"
         identifier_type = email
@@ -1206,7 +1218,7 @@ struct FailureDetailsLogInfo
     example default
         user_friendly_message = "abc"
         technical_error_message = "abc"
-    
+
     example default2
         user_friendly_message = "xyz"
         technical_error_message = "xyz"
@@ -1219,7 +1231,7 @@ struct FileLogInfo extends FileOrFolderLogInfo
         display_name = "reports.xls"
         file_id = "id:jQKLsZFQImAAAAAAEZAAQt"
         file_size = 3
-    
+
     example default2
         path = default2
         display_name = "reports.xls"
@@ -1236,7 +1248,7 @@ struct FileRequestDeadline
     example default
         deadline = "2017-01-25T15:51:30Z"
         allow_late_uploads = "one_day"
-    
+
     example default2
         deadline = "2017-01-25T15:51:30Z"
         allow_late_uploads = "one_day"
@@ -1254,7 +1266,7 @@ struct FileRequestDetails
         asset_index = 3
         deadline = default
         has_password = true
-    
+
     example default2
         asset_index = 4
         deadline = default2
@@ -1271,7 +1283,7 @@ struct FolderLogInfo extends FileOrFolderLogInfo
         file_id = "id:jQKLsZFQImAAAAAAEZAAQt"
         file_size = 3
         file_count = 3
-    
+
     example default2
         path = default2
         display_name = "reports.xls"
@@ -1292,7 +1304,7 @@ struct GroupLogInfo
         group_id = "g:e2db7665347abcd600000000001a2b3c"
         display_name = "abc"
         external_id = "some group id"
-    
+
     example default2
         group_id = "g:hujn7665347abcd600000000001a2b3d"
         display_name = "xyz"
@@ -1301,16 +1313,22 @@ struct GroupLogInfo
 struct JoinTeamDetails
     "Additional information relevant when a new member joins the team."
     linked_apps List(UserLinkedAppLogInfo)
+        @common.Deprecated
         "Linked applications. (Deprecated) Please use has_linked_apps boolean field instead."
     linked_devices List(LinkedDeviceLogInfo)
+        @common.Deprecated
         "Linked devices. (Deprecated) Please use has_linked_devices boolean field instead."
     linked_shared_folders List(FolderLogInfo)
+        @common.Deprecated
         "Linked shared folders. (Deprecated) Please use has_linked_shared_folders boolean field instead."
     was_linked_apps_truncated Boolean?
+        @common.Deprecated
         "(Deprecated) True if the linked_apps list was truncated to the maximum supported length (50)."
     was_linked_devices_truncated Boolean?
+        @common.Deprecated
         "(Deprecated) True if the linked_devices list was truncated to the maximum supported length (50)."
     was_linked_shared_folders_truncated Boolean?
+        @common.Deprecated
         "(Deprecated) True if the linked_shared_folders list was truncated to the maximum supported length (50)."
     has_linked_apps Boolean?
         "True if the user had linked apps at event time."
@@ -1329,7 +1347,7 @@ struct JoinTeamDetails
         has_linked_apps = true
         has_linked_devices = true
         has_linked_shared_folders = true
-    
+
     example default2
         linked_apps = [default2]
         linked_devices = [default2]
@@ -1375,7 +1393,7 @@ struct LegacyDeviceSessionLogInfo extends DeviceSessionLogInfo
         device_type = "abc"
         client_version = "abc"
         legacy_uniq_id = "abc"
-    
+
     example default2
         ip_address = "45.56.78.100"
         created = "2017-01-25T15:51:30Z"
@@ -1412,7 +1430,7 @@ struct LinkSettingsLogInfo
         expire_at = "2017-01-25T15:51:30Z"
         password_required = true
         url = "abc"
-    
+
     example default2
         name = "xyz"
         require_email = false
@@ -1434,7 +1452,7 @@ struct MalwareExclusionState
         excluded_file_hashes_count = 3
         file_path_from_last_exclusion = "abc"
         file_path_from_last_inclusion = "abc"
-    
+
     example default2
         excluded_file_hashes_count = 4
         file_path_from_last_exclusion = "xyz"
@@ -1450,7 +1468,7 @@ struct MemberTransferredInternalFields
     example default
         source_team_id = "dbtid:AAE3tIYgVuVT1gZork5wQJbXbmlrkBMq26c"
         target_team_id = "dbtid:AAE3tIYgVuVT1gZork5wQJbXbmlrkBMq26c"
-    
+
     example default2
         source_team_id = "dbtid:AAFAqKNLrx_W9MFkS2gWftX0QfTZpo03WsE"
         target_team_id = "dbtid:AAFAqKNLrx_W9MFkS2gWftX0QfTZpo03WsE"
@@ -1480,7 +1498,7 @@ struct MobileDeviceSessionLogInfo extends DeviceSessionLogInfo
         client_version = "abc"
         os_version = "abc"
         last_carrier = "abc"
-    
+
     example default2
         ip_address = "45.56.78.100"
         created = "2017-01-25T15:51:30Z"
@@ -1497,7 +1515,7 @@ struct MobileSessionLogInfo extends SessionLogInfo
 
     example default
         session_id = "dbwsid:123456789012345678901234567890123456789"
-    
+
     example default2
         session_id = "dbwsid:abcd5678901234567890123456789012345abcd"
 
@@ -1514,7 +1532,7 @@ struct NamespaceRelativePathLogInfo
         ns_id = "1234"
         relative_path = "/Contract Work/Product Design"
         is_shared_namespace = true
-    
+
     example default2
         ns_id = "1234"
         relative_path = "/Contract Work/Draft"
@@ -1527,7 +1545,7 @@ struct NonTeamMemberLogInfo extends UserLogInfo
         account_id = "dbid:AAHgR8xsQP48a5DQUGPo-Vxsrjd0OByVmho"
         display_name = "John Smith"
         email = "john_smith@acmecorp.com"
-    
+
     example default2
         account_id = "dbid:AAGx4oiLtHdvRdNxUpvvJBXYgR4BS19c9kw"
         display_name = "Jane Smith"
@@ -1540,7 +1558,7 @@ struct NonTrustedTeamDetails
 
     example default
         team = "abc"
-    
+
     example default2
         team = "xyz"
 
@@ -1551,7 +1569,7 @@ struct OrganizationDetails
 
     example default
         organization = "My Organization"
-    
+
     example default2
         organization = "My Organization"
 
@@ -1562,7 +1580,7 @@ struct OrganizationName
 
     example default
         organization = "My Organization"
-    
+
     example default2
         organization = "My Organization"
 
@@ -1576,7 +1594,7 @@ struct PaperDocumentLogInfo
     example default
         doc_id = "abc"
         doc_title = "abc"
-    
+
     example default2
         doc_id = "xyz"
         doc_title = "xyz"
@@ -1591,7 +1609,7 @@ struct PaperFolderLogInfo
     example default
         folder_id = "abc"
         folder_name = "abc"
-    
+
     example default2
         folder_id = "xyz"
         folder_name = "xyz"
@@ -1606,7 +1624,7 @@ struct PathLogInfo
     example default
         contextual = "/Contract Work/Product Design"
         namespace_relative = default
-    
+
     example default2
         contextual = "/Contract Work/Draft"
         namespace_relative = default2
@@ -1621,7 +1639,7 @@ struct PrimaryTeamRequestAcceptedDetails
     example default
         secondary_team = "IT Department"
         sent_by = "Dan Eveninglily"
-    
+
     example default2
         secondary_team = "IT Department"
         sent_by = "Dan Eveninglily"
@@ -1636,7 +1654,7 @@ struct PrimaryTeamRequestCanceledDetails
     example default
         secondary_team = "IT Department"
         sent_by = "Dan Eveninglily"
-    
+
     example default2
         secondary_team = "IT Department"
         sent_by = "Dan Eveninglily"
@@ -1651,7 +1669,7 @@ struct PrimaryTeamRequestExpiredDetails
     example default
         secondary_team = "IT Department"
         sent_by = "Dan Eveninglily"
-    
+
     example default2
         secondary_team = "IT Department"
         sent_by = "Dan Eveninglily"
@@ -1666,7 +1684,7 @@ struct PrimaryTeamRequestReminderDetails
     example default
         secondary_team = "IT Department"
         sent_to = "Dan Eveninglily"
-    
+
     example default2
         secondary_team = "IT Department"
         sent_to = "Dan Eveninglily"
@@ -1678,7 +1696,7 @@ struct ProductLogInfo
 
     example default
         product_name = "abc"
-    
+
     example default2
         product_name = "xyz"
 
@@ -1695,7 +1713,7 @@ struct RecipientsConfiguration
         recipient_setting_type = invalid
         emails = ["john_smith@acmecorp.com"]
         groups = ["abc"]
-    
+
     example default2
         recipient_setting_type = invalid
         emails = ["jane_smith@acmecorp.com"]
@@ -1711,7 +1729,7 @@ struct RelocateAssetReferencesLogInfo
     example default
         src_asset_index = 3
         dest_asset_index = 3
-    
+
     example default2
         src_asset_index = 4
         dest_asset_index = 4
@@ -1726,7 +1744,7 @@ struct SecondaryTeamRequestAcceptedDetails
     example default
         primary_team = "IT Department"
         sent_by = "Dan Eveninglily"
-    
+
     example default2
         primary_team = "IT Department"
         sent_by = "Dan Eveninglily"
@@ -1741,7 +1759,7 @@ struct SecondaryTeamRequestCanceledDetails
     example default
         sent_to = "admin@it_department.com"
         sent_by = "Dan Eveninglily"
-    
+
     example default2
         sent_to = "admin@it_department.com"
         sent_by = "Dan Eveninglily"
@@ -1753,7 +1771,7 @@ struct SecondaryTeamRequestExpiredDetails
 
     example default
         sent_to = "admin@it_department.com"
-    
+
     example default2
         sent_to = "admin@it_department.com"
 
@@ -1764,7 +1782,7 @@ struct SecondaryTeamRequestReminderDetails
 
     example default
         sent_to = "admin@it_department.com"
-    
+
     example default2
         sent_to = "admin@it_department.com"
 
@@ -1779,7 +1797,7 @@ struct SessionLogInfo
 
     example default
         desktop = default
-    
+
     example default2
         desktop = default2
 
@@ -1793,7 +1811,7 @@ struct ShowcaseDocumentLogInfo
     example default
         showcase_id = "fvti8SoWq5tdyM1YMXl5z"
         showcase_title = "Sample Showcase Proposal"
-    
+
     example default2
         showcase_id = "fvti8SoWq5tdyM1YMXl5z"
         showcase_title = "Sample Showcase Proposal"
@@ -1805,7 +1823,7 @@ struct TeamDetails
 
     example default
         team = "My Team"
-    
+
     example default2
         team = "My Team"
 
@@ -1819,7 +1837,7 @@ struct TeamInviteDetails
     example default
         invite_method = invite_link
         additional_license_purchase = true
-    
+
     example default2
         invite_method = invite_link
         additional_license_purchase = false
@@ -1830,7 +1848,7 @@ struct TeamLinkedAppLogInfo extends AppLogInfo
     example default
         app_id = "dbaid:AAFhvuxku2OYumUaV17x6ExFhr6OPrwjTKs"
         display_name = "abc"
-    
+
     example default2
         app_id = "dbaid:AAG1NxJeBtby__IZENPAvDGeOssreFpPALE"
         display_name = "xyz"
@@ -1842,7 +1860,7 @@ struct TeamLogInfo
 
     example default
         display_name = "A Team"
-    
+
     example default2
         display_name = "A Team"
 
@@ -1862,7 +1880,7 @@ struct TeamMemberLogInfo extends UserLogInfo
         team_member_id = "dbmid:AAFoi-tmvRuQR0jU-3fN4B-9nZo6nHcDO9Q"
         member_external_id = "ADSYNC S-1-5-21-1004296348-1135238915-682003432-1224"
         team = default
-    
+
     example default2
         account_id = "dbid:AAGx4oiLtHdvRdNxUpvvJBXYgR4BS19c9kw"
         display_name = "Jane Smith"
@@ -1881,7 +1899,7 @@ struct TeamName
     example default
         team_display_name = "abc"
         team_legal_name = "abc"
-    
+
     example default2
         team_display_name = "xyz"
         team_legal_name = "xyz"
@@ -1899,7 +1917,7 @@ struct TrustedNonTeamMemberLogInfo extends UserLogInfo
         email = "john_smith@acmecorp.com"
         trusted_non_team_member_type = multi_instance_admin
         team = default
-    
+
     example default2
         account_id = "dbid:AAGx4oiLtHdvRdNxUpvvJBXYgR4BS19c9kw"
         display_name = "Jane Smith"
@@ -1913,7 +1931,7 @@ struct UserLinkedAppLogInfo extends AppLogInfo
     example default
         app_id = "dbaid:AAFhvuxku2OYumUaV17x6ExFhr6OPrwjTKs"
         display_name = "abc"
-    
+
     example default2
         app_id = "dbaid:AAG1NxJeBtby__IZENPAvDGeOssreFpPALE"
         display_name = "xyz"
@@ -1933,7 +1951,7 @@ struct UserLogInfo
 
     example default
         non_team_member = default
-    
+
     example default2
         non_team_member = default2
 
@@ -1950,7 +1968,7 @@ struct UserNameLogInfo
         given_name = "abc"
         surname = "abc"
         locale = "abc"
-    
+
     example default2
         given_name = "xyz"
         surname = "xyz"
@@ -1962,7 +1980,7 @@ struct UserOrTeamLinkedAppLogInfo extends AppLogInfo
     example default
         app_id = "dbaid:AAFhvuxku2OYumUaV17x6ExFhr6OPrwjTKs"
         display_name = "abc"
-    
+
     example default2
         app_id = "dbaid:AAG1NxJeBtby__IZENPAvDGeOssreFpPALE"
         display_name = "xyz"
@@ -1986,7 +2004,7 @@ struct WebDeviceSessionLogInfo extends DeviceSessionLogInfo
         user_agent = "abc"
         os = "abc"
         browser = "abc"
-    
+
     example default2
         ip_address = "45.56.78.100"
         created = "2017-01-25T15:51:30Z"
@@ -2001,7 +2019,7 @@ struct WebSessionLogInfo extends SessionLogInfo
 
     example default
         session_id = "dbwsid:123456789012345678901234567890123456789"
-    
+
     example default2
         session_id = "dbwsid:abcd5678901234567890123456789012345abcd"
 
@@ -2012,7 +2030,7 @@ struct ApiSessionLogInfo
 
     example default
         request_id = "dbarid:f451ce673cc5da6818aed4c160a3ebaa"
-    
+
     example default2
         request_id = "dbarid:f451ce673cc5da6818aed4c160a3ebaa"
 
@@ -2032,7 +2050,7 @@ struct FileOrFolderLogInfo
         display_name = "reports.xls"
         file_id = "id:jQKLsZFQImAAAAAAEZAAQt"
         file_size = 3
-    
+
     example default2
         path = default2
         display_name = "reports.xls"
@@ -2055,7 +2073,7 @@ struct GeoLocationLogInfo
         region = "California"
         country = "US"
         ip_address = "45.56.78.100"
-    
+
     example default2
         city = "San Francisco"
         region = "California"
@@ -2077,7 +2095,7 @@ struct OriginLogInfo
     example default
         geo_location = default
         access_method = default
-    
+
     example default2
         geo_location = default2
         access_method = default2
@@ -2092,7 +2110,7 @@ struct ResellerLogInfo
     example default
         reseller_name = "abc"
         reseller_email = "john_smith@acmecorp.com"
-    
+
     example default2
         reseller_name = "xyz"
         reseller_email = "jane_smith@acmecorp.com"
@@ -2114,7 +2132,7 @@ union AccessMethodLogInfo
 
     example default
         end_user = default
-    
+
     example default2
         end_user = default2
 
@@ -2135,7 +2153,7 @@ union ActorLogInfo
 
     example default
         user = default
-    
+
     example default2
         user = default2
 
@@ -2156,7 +2174,7 @@ union ContextLogInfo
 
     example default
         team_member = default
-    
+
     example default2
         team_member = default2
 
@@ -6315,6 +6333,39 @@ struct TeamFolderRenameDetails
         previous_folder_name = "abc"
         new_folder_name = "abc"
 
+struct TeamFolderSpaceLimitsChangeCapsTypeDetails
+    "Changed team folder space limit enforcement type."
+    previous_caps_type TeamFolderSpaceCapsType?
+        "Previous enforcement type."
+    new_caps_type TeamFolderSpaceCapsType
+        "New enforcement type."
+
+    example default
+        previous_caps_type = off
+        new_caps_type = off
+
+struct TeamFolderSpaceLimitsChangeLimitDetails
+    "Changed team folder space limit."
+    previous_limit_bytes Int64?
+        "Previous limit in bytes."
+    new_limit_bytes Int64
+        "New limit in bytes."
+
+    example default
+        previous_limit_bytes = 3
+        new_limit_bytes = 3
+
+struct TeamFolderSpaceLimitsChangeNotificationTargetDetails
+    "Changed team folder space limit notification target."
+    previous_target TeamFolderNotificationTarget?
+        "Previous notification target."
+    new_target TeamFolderNotificationTarget
+        "New notification target."
+
+    example default
+        previous_target = admins
+        new_target = admins
+
 struct TeamSelectiveSyncSettingsChangedDetails
     "Changed sync default."
     previous_value files.SyncSetting
@@ -8195,6 +8246,9 @@ union EventDetails
     team_folder_downgrade_details TeamFolderDowngradeDetails
     team_folder_permanently_delete_details TeamFolderPermanentlyDeleteDetails
     team_folder_rename_details TeamFolderRenameDetails
+    team_folder_space_limits_change_caps_type_details TeamFolderSpaceLimitsChangeCapsTypeDetails
+    team_folder_space_limits_change_limit_details TeamFolderSpaceLimitsChangeLimitDetails
+    team_folder_space_limits_change_notification_target_details TeamFolderSpaceLimitsChangeNotificationTargetDetails
     team_selective_sync_settings_changed_details TeamSelectiveSyncSettingsChangedDetails
     account_capture_change_policy_details AccountCaptureChangePolicyDetails
     admin_email_reminders_changed_details AdminEmailRemindersChangedDetails
@@ -11043,6 +11097,24 @@ struct TeamFolderRenameType
     example default
         description = "(team_folders) Renamed active/archived team folder"
 
+struct TeamFolderSpaceLimitsChangeCapsTypeType
+    description String
+
+    example default
+        description = "(team_folders) Changed team folder space limit enforcement type"
+
+struct TeamFolderSpaceLimitsChangeLimitType
+    description String
+
+    example default
+        description = "(team_folders) Changed team folder space limit"
+
+struct TeamFolderSpaceLimitsChangeNotificationTargetType
+    description String
+
+    example default
+        description = "(team_folders) Changed team folder space limit notification target"
+
 struct TeamSelectiveSyncSettingsChangedType
     description String
 
@@ -12865,6 +12937,12 @@ union EventType
         "(team_folders) Permanently deleted archived team folder"
     team_folder_rename TeamFolderRenameType
         "(team_folders) Renamed active/archived team folder"
+    team_folder_space_limits_change_caps_type TeamFolderSpaceLimitsChangeCapsTypeType
+        "(team_folders) Changed team folder space limit enforcement type"
+    team_folder_space_limits_change_limit TeamFolderSpaceLimitsChangeLimitType
+        "(team_folders) Changed team folder space limit"
+    team_folder_space_limits_change_notification_target TeamFolderSpaceLimitsChangeNotificationTargetType
+        "(team_folders) Changed team folder space limit notification target"
     team_selective_sync_settings_changed TeamSelectiveSyncSettingsChangedType
         "(team_folders) Changed sync default"
     account_capture_change_policy AccountCaptureChangePolicyType
@@ -14075,6 +14153,12 @@ union EventTypeArg
         "(team_folders) Permanently deleted archived team folder"
     team_folder_rename
         "(team_folders) Renamed active/archived team folder"
+    team_folder_space_limits_change_caps_type
+        "(team_folders) Changed team folder space limit enforcement type"
+    team_folder_space_limits_change_limit
+        "(team_folders) Changed team folder space limit"
+    team_folder_space_limits_change_notification_target
+        "(team_folders) Changed team folder space limit notification target"
     team_selective_sync_settings_changed
         "(team_folders) Changed sync default"
     account_capture_change_policy

--- a/users.stone
+++ b/users.stone
@@ -6,48 +6,35 @@ import team_common
 import team_policies
 import users_common
 
-route get_space_usage (Void, SpaceUsage, Void)
-    "Get the space usage information for the current user's account."
+struct Name
+    "Representations for a person's name to assist with internationalization."
+    given_name String
+        "Also known as a first name."
+    surname String
+        "Also known as a last name or family name."
+    familiar_name String
+        "Locale-dependent name. In the US, a person's familiar name is their
+        :field:`given_name`, but elsewhere, it could be any combination of a
+        person's :field:`given_name` and :field:`surname`."
+    display_name String
+        "A name that can be used directly to represent the name of a user's
+        Dropbox account."
+    abbreviated_name String
+        "An abbreviated form of the person's name. Their initials in most locales."
 
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "account_info.read"
+    example default
+        given_name = "Franz"
+        surname = "Ferdinand"
+        familiar_name = "Franz"
+        display_name = "Franz Ferdinand (Personal)"
+        abbreviated_name = "FF"
 
-
-route get_account (GetAccountArg, BasicAccount, GetAccountError)
-    "Get information about a user's account."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "sharing.read"
-
-route get_account_batch (GetAccountBatchArg, GetAccountBatchResult, GetAccountBatchError)
-    "Get information about multiple user accounts. At most 300 accounts may be queried per request."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "sharing.read"
-
-route get_current_account (Void, FullAccount, Void)
-    "Get information about the current user's account."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "account_info.read"
-        select_admin_mode = "whole_team"
-
-
-route features/get_values (UserFeaturesGetValuesBatchArg, UserFeaturesGetValuesBatchResult, UserFeaturesGetValuesBatchError)
-    "Get a list of feature values that may be configured for the current account."
-
-    attrs
-        allow_app_folder_app = true
-        auth = "user"
-        scope = "account_info.read"
+    example second_name
+        given_name = "Zexy Desperado"
+        surname = "Desperado"
+        familiar_name = "Zexy"
+        display_name = "Zexy Desperado (Personal)"
+        abbreviated_name = "ZD"
 
 
 alias GetAccountBatchResult = List(BasicAccount)
@@ -176,7 +163,7 @@ struct BasicAccount extends Account
         profile_photo_url = "https://dl-web.dropbox.com/account_photo/get/dbaphid%3AAAHWGmIXV3sUuOmBfTz0wPsiqHUpBWvv3ZA?vers=1556069330102&size=128x128"
         is_teammate = false
         disabled = false
-    
+
     example team
         account_id = "dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc"
         name = default
@@ -225,7 +212,7 @@ struct FullAccount extends Account
         account_type = business
         disabled = false
         root_info = default
-    
+
     example unpaired
         account_id = "dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc"
         name = default
@@ -335,33 +322,46 @@ struct UserFeaturesGetValuesBatchResult
         values = [paper_as_files_enabled]
 
 
-struct Name
-    "Representations for a person's name to assist with internationalization."
-    given_name String
-        "Also known as a first name."
-    surname String
-        "Also known as a last name or family name."
-    familiar_name String
-        "Locale-dependent name. In the US, a person's familiar name is their
-        :field:`given_name`, but elsewhere, it could be any combination of a
-        person's :field:`given_name` and :field:`surname`."
-    display_name String
-        "A name that can be used directly to represent the name of a user's
-        Dropbox account."
-    abbreviated_name String
-        "An abbreviated form of the person's name. Their initials in most locales."
+route get_account (GetAccountArg, BasicAccount, GetAccountError)
+    "Get information about a user's account."
 
-    example default
-        given_name = "Franz"
-        surname = "Ferdinand"
-        familiar_name = "Franz"
-        display_name = "Franz Ferdinand (Personal)"
-        abbreviated_name = "FF"
-    
-    example second_name
-        given_name = "Zexy Desperado"
-        surname = "Desperado"
-        familiar_name = "Zexy"
-        display_name = "Zexy Desperado (Personal)"
-        abbreviated_name = "ZD"
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "sharing.read"
+
+route get_account_batch (GetAccountBatchArg, GetAccountBatchResult, GetAccountBatchError)
+    "Get information about multiple user accounts. At most 300 accounts may be queried per request."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "sharing.read"
+
+route get_current_account (Void, FullAccount, Void)
+    "Get information about the current user's account."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "account_info.read"
+        select_admin_mode = "whole_team"
+
+
+route features/get_values (UserFeaturesGetValuesBatchArg, UserFeaturesGetValuesBatchResult, UserFeaturesGetValuesBatchError)
+    "Get a list of feature values that may be configured for the current account."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "account_info.read"
+
+
+route get_space_usage (Void, SpaceUsage, Void)
+    "Get the space usage information for the current user's account."
+
+    attrs
+        allow_app_folder_app = true
+        auth = "user"
+        scope = "account_info.read"
 


### PR DESCRIPTION
## Summary
- Add `delete_profile_photo` route to account namespace
- Add `get_markdown_async` and `get_markdown_async/check` routes to riviera namespace
- Add `update_file_policy` route to sharing namespace
- Add `@common.Deprecated` field annotations to files, sharing, team, team_log namespaces
- Update comments in files namespace
