### PR TITLE
Spec Update 06/29/2026

### DIFF
--- a/files.stone
+++ b/files.stone
@@ -15,7 +15,7 @@ route search:2 (SearchV2Arg, SearchV2Result, SearchError)
 
     attrs
         allow_app_folder_app = true
-        auth = "app, user"
+        auth = "user"
         scope = "files.metadata.read"
 
 route search/continue:2 (SearchV2ContinueArg, SearchV2Result, SearchError)
@@ -27,7 +27,7 @@ route search/continue:2 (SearchV2ContinueArg, SearchV2Result, SearchError)
 
     attrs
         allow_app_folder_app = true
-        auth = "app, user"
+        auth = "user"
         scope = "files.metadata.read"
 
 
@@ -832,6 +832,8 @@ struct FileMetadata extends Metadata
         information see our :link:`Content hash https://www.dropbox.com/developers/reference/content-hash` page."
     file_lock_info FileLockMetadata?
         "If present, the metadata associated with the file's current lock."
+    is_restorable Boolean?
+        "If present, indicates whether this file revision can be restored."
 
     example default
         id = "id:a4ayc_80_OEAAAAAAAAAXw"
@@ -886,6 +888,8 @@ struct FolderMetadata extends Metadata
 
 struct DeletedMetadata extends Metadata
     "Indicates that there used to be a file or folder at this path, but it no longer exists."
+    is_restorable Boolean?
+        "If present, indicates whether this deleted entry can be restored."
 
     example default
         path_lower = "/homework/math/pi.txt"
@@ -1820,6 +1824,8 @@ struct ListFolderArg
         listed templates."
     include_non_downloadable_files Boolean = true
         "If true, include files that are not downloadable, i.e. Google Docs."
+    include_restorable_info Boolean = false
+        "If true, each returned deleted entry will include whether that entry can be restored."
 
     example default
         path = "/Homework/math"
@@ -1892,6 +1898,8 @@ struct ListRevisionsArg
     before_rev Rev?
         "If set, ListRevisions will only return revisions prior to before_rev. Can be set using the last revision
         from a previous call to list_revisions to fetch the next page of revisions. Only supported in path mode."
+    include_restorable_info Boolean = false
+        "If true, each returned revision will include whether that revision can be restored."
 
     example default
         path = "/root/word.docx"

--- a/sharing.stone
+++ b/sharing.stone
@@ -254,12 +254,12 @@ route create_shared_link (CreateSharedLinkArg, PathLinkMetadata, CreateSharedLin
         select_admin_mode = "team_admin"
 
 route get_shared_links (GetSharedLinksArg, GetSharedLinksResult, GetSharedLinksError) deprecated
-    "Returns a list of :type:`LinkMetadata` objects for this user, including collection links.
+    "DEPRECATED: Use list_shared_links instead. This endpoint will be retired in October 2026.
+    Returns a list of :type:`LinkMetadata` objects for this user, including collection links.
     If no path is given, returns a list of all shared links for the current user,
     including collection links, up to a maximum of 1000 links.
     If a non-empty path is given, returns a list of all shared links that allow access
-    to the given path. Collection links are never returned in this case.
-    DEPRECATED: Use list_shared_links instead."
+    to the given path. Collection links are never returned in this case."
 
     attrs
         allow_app_folder_app = true

--- a/team_log.stone
+++ b/team_log.stone
@@ -775,6 +775,7 @@ union TeamFolderNotificationTarget
 
 union TeamFolderSpaceCapsType
     "Team folder space limit enforcement type"
+    hard
     off
     soft
 
@@ -2210,6 +2211,8 @@ union EventCategory
         "Events that apply to Dropbox Paper."
     passwords
         "Events that involve using, changing or resetting passwords."
+    protect
+        "Events that apply to Dropbox Protect"
     reports
         "Events that concern generation of admin reports, including team activity and device usage."
     sharing
@@ -4826,6 +4829,17 @@ struct PasswordResetDetails
 struct PasswordResetAllDetails
     "Reset all team member passwords."
 
+struct ProtectInternalDomainsChangedDetails
+    "Modified Protect internal domains list."
+    domains_added List(String)?
+        "Domains added to the internal domains list."
+    domains_removed List(String)?
+        "Domains removed from the internal domains list."
+
+    example default
+        domains_added = ["abc"]
+        domains_removed = ["abc"]
+
 struct ClassificationCreateReportDetails
     "Created Classification report."
 
@@ -6341,8 +6355,8 @@ struct TeamFolderSpaceLimitsChangeCapsTypeDetails
         "New enforcement type."
 
     example default
-        previous_caps_type = off
-        new_caps_type = off
+        previous_caps_type = hard
+        new_caps_type = hard
 
 struct TeamFolderSpaceLimitsChangeLimitDetails
     "Changed team folder space limit."
@@ -8073,6 +8087,7 @@ union EventDetails
     password_change_details PasswordChangeDetails
     password_reset_details PasswordResetDetails
     password_reset_all_details PasswordResetAllDetails
+    protect_internal_domains_changed_details ProtectInternalDomainsChangedDetails
     classification_create_report_details ClassificationCreateReportDetails
     classification_create_report_fail_details ClassificationCreateReportFailDetails
     emm_create_exceptions_report_details EmmCreateExceptionsReportDetails
@@ -10058,6 +10073,12 @@ struct PasswordResetAllType
 
     example default
         description = "(passwords) Reset all team member passwords"
+
+struct ProtectInternalDomainsChangedType
+    description String
+
+    example default
+        description = "(protect) Modified Protect internal domains list"
 
 struct ClassificationCreateReportType
     description String
@@ -12591,6 +12612,8 @@ union EventType
         "(passwords) Reset password"
     password_reset_all PasswordResetAllType
         "(passwords) Reset all team member passwords"
+    protect_internal_domains_changed ProtectInternalDomainsChangedType
+        "(protect) Modified Protect internal domains list"
     classification_create_report ClassificationCreateReportType
         "(reports) Created Classification report"
     classification_create_report_fail ClassificationCreateReportFailType
@@ -13807,6 +13830,8 @@ union EventTypeArg
         "(passwords) Reset password"
     password_reset_all
         "(passwords) Reset all team member passwords"
+    protect_internal_domains_changed
+        "(protect) Modified Protect internal domains list"
     classification_create_report
         "(reports) Created Classification report"
     classification_create_report_fail


### PR DESCRIPTION
## Summary

- **files**: Remove app auth from `search:2` and `search/continue:2`; add `is_restorable` field to `FileMetadata` and `DeletedMetadata`; add `include_restorable_info` param to `ListFolderArg` and `ListRevisionsArg`
- **sharing**: Update `get_shared_links` deprecation notice with October 2026 retirement date
- **team_log**: Add Dropbox Protect audit events (`ProtectInternalDomainsChanged`); add `hard` variant to `TeamFolderSpaceCapsType`; add `protect` event category
- Remove unreachable `rialto` namespace

## Change Notes

files Namespace:
- Update search:2 route to remove app auth
- Update search/continue:2 route to remove app auth
- Update FileMetadata struct to include is_restorable
- Update DeletedMetadata struct to include is_restorable
- Update ListFolderArg struct to include include_restorable_info
- Update ListRevisionsArg struct to include include_restorable_info

sharing Namespace:
- Update get_shared_links route deprecation notice (retirement October 2026)

team_log Namespace:
- Update TeamFolderSpaceCapsType union to include hard
- Update EventCategory union to include protect
- Add ProtectInternalDomainsChangedDetails struct
- Add ProtectInternalDomainsChangedType struct
- Update EventDetails union to include protect_internal_domains_changed_details
- Update EventType union to include protect_internal_domains_changed
- Update EventTypeArg union to include protect_internal_domains_changed
- Update Examples

Remove rialto Namespace