### PR TITLE
Spec Update 07/13/2026

### DIFF
--- a/common.stone
+++ b/common.stone
@@ -76,6 +76,7 @@ union PathRootError
 
 
 # Annotates fields to serialize a subset of total fields, depending on caller type
+annotation InternalOnly = Omitted("internal")
 
 # Annotates fields to redact information before storing in logs
 

--- a/files.stone
+++ b/files.stone
@@ -338,6 +338,7 @@ union_closed ThumbnailSize
     w2048h1536
         "2048 by 1536 px."
     w3200h2400
+        @common.InternalOnly
         "3200 by 2400 px."
 
 union_closed SearchMatchType
@@ -2258,6 +2259,7 @@ struct ThumbnailArg
     mode ThumbnailMode = strict
         "How to resize and crop the image to achieve the desired size."
     quality ThumbnailQuality = quality_80
+        @common.InternalOnly
         "Quality of the thumbnail image."
     exclude_media_info Boolean?
         "Normally, :field:`FileMetadata.media_info` is set for photo and video.
@@ -2289,6 +2291,7 @@ struct ThumbnailV2Arg
     mode ThumbnailMode = strict
         "How to resize and crop the image to achieve the desired size."
     quality ThumbnailQuality = quality_80
+        @common.InternalOnly
         "Quality of the thumbnail image."
     exclude_media_info Boolean?
         "Normally, :field:`FileMetadata.media_info` is set for photo and video.

--- a/riviera.stone
+++ b/riviera.stone
@@ -34,6 +34,10 @@ union ContentApiV2Error
     link_download_disabled_error
     shared_link_password_protected
     limit_exceeded_error
+    not_found_error
+        "The referenced file does not exist or is not accessible."
+    is_a_folder_error
+        "The target is a folder, not a file."
 
 struct GetTranscriptAsyncError
     error_code ErrorCode = unknown_error
@@ -81,9 +85,9 @@ struct GetTranscriptArgs
         stripped. Unrecognized tokens are ignored. Leave empty to use the
         default filtering behavior."
     audio_language String = ""
-        "Optional BCP-47 language tag hinting the spoken language of the source
-        audio (e.g. \"en-US\", \"ja-JP\"). When empty, the service auto-detects the
-        language; supplying a hint improves accuracy and latency for short or
+        "Optional ISO 639-1 two-letter language code hinting the spoken language of
+        the source audio (e.g. \"en\", \"ja\"). When empty, the service auto-detects
+        the language; supplying a hint improves accuracy and latency for short or
         ambiguous clips. Unsupported languages fall back to auto-detection."
 
 struct ApiTranscriptSegment
@@ -168,6 +172,10 @@ union MarkdownConversionApiV2Error
     shared_link_password_protected
     limit_exceeded_error
     conversion_failure_error
+    not_found_error
+        "The referenced file does not exist or is not accessible."
+    is_a_folder_error
+        "The target is a folder, not a file."
 
 struct GetMarkdownAsyncError
     error_code ErrorCode = unknown_error
@@ -189,6 +197,200 @@ route get_markdown_async (GetMarkdownArgs, async.LaunchResultBase, Void)
 
 route get_markdown_async/check (async.PollArg, GetMarkdownAsyncCheckResult, async.PollError)
     "Returns the status or result of specified get_markdown_async task."
+
+    attrs
+        auth = "app, user"
+        is_preview = true
+        scope = "files.content.read"
+
+
+union OfficeFileType
+    "The kind of MS Office document that produced an `ApiOfficeMetadata` result."
+    office_filetype_unknown
+    office_filetype_word
+    office_filetype_powerpoint
+    office_filetype_excel
+
+
+union MetadataType
+    "Which metadata variant is populated in a `GetMetadataResult`, derived from
+    the file type."
+    metadata_type_unknown
+    metadata_type_exif
+    metadata_type_media
+    metadata_type_pdf
+    metadata_type_office
+
+
+struct GetMetadataArgs
+    "Arguments for the asynchronous `get_metadata_async` route.
+    Exactly one of `file_id`, `path`, or `url` must be supplied via
+    `file_id_or_url` to identify the file whose metadata should be extracted."
+    file_id_or_url FileIdOrUrl?
+        "Identifier of the file to extract metadata from. Callers must set exactly
+        one of the oneof variants:
+        - file_id: a Dropbox-issued file id (format: \"id:<id>\") for a file the
+        authenticated user has access to.
+        - path: an absolute Dropbox path, e.g. \"/folder/photo.jpg\".
+        - url: either a Dropbox shared link (www.dropbox.com) or an external
+        HTTPS URL pointing to a supported file.
+        - Dropbox shared links are resolved internally using the caller's
+        authenticated identity and the link's visibility / download
+        settings. They therefore require an authenticated user context
+        (anonymous `url` requests against Dropbox links are rejected with
+        an `ACCESS_ERROR`). Links protected by a password are rejected
+        with `shared_link_password_protected`; links with downloads
+        disabled are rejected with `link_download_disabled_error`.
+        - External URLs are fetched over HTTPS through the backend's
+        egress proxy and must point at a supported file extension.
+        The kind of metadata returned is determined by the file type: image files
+        return EXIF metadata, audio/video files return media metadata, PDFs return
+        PDF metadata, and MS Office documents (docx, pptx, xlsx) return Office
+        metadata. Requests against unsupported formats return
+        `unsupported_format_error`."
+
+struct ApiExifGpsMetadata
+    "GPS coordinates and related tags extracted from image EXIF data. Fields are
+    populated on a best-effort basis and may be empty when absent from the
+    source file."
+    latitude Float32 = 0
+        "Latitude / longitude in decimal degrees (positive = N/E, negative = S/W)."
+    longitude Float32 = 0
+    altitude String = ""
+        "Altitude in meters, as reported by the source (string to preserve the
+        original representation, which may include a reference direction)."
+    timestamp String = ""
+        "Timestamp / datestamp of the GPS fix, in the EXIF-provided format."
+    datestamp String = ""
+
+struct ApiExifMetadata
+    "Image EXIF metadata. Mirrors the useful subset of the internal
+    `riviera.ExifMetadata` message. Fields are best-effort and may be empty."
+    image_width UInt32 = 0
+    image_height UInt32 = 0
+    camera_make String = ""
+    camera_model String = ""
+    lens_model String = ""
+    date_time_original String = ""
+        "Capture time in the EXIF-provided format (local time of the camera)."
+    offset_time_original String = ""
+        "Timezone offset for `date_time_original`, e.g. \"+09:00\"."
+    orientation UInt32 = 0
+        "EXIF orientation value (1-8). See the EXIF spec; 1 is the normal
+        upright orientation."
+    exposure_time String = ""
+        "fraction in string form, e.g. \"1/250\""
+    aperture_value Float64 = 0
+    iso_speed UInt32 = 0
+    focal_length String = ""
+        "e.g. \"26.0 mm\""
+    megapixels Float64 = 0
+    artist String = ""
+    copyright String = ""
+    gps_metadata ApiExifGpsMetadata?
+
+struct ApiMediaStream
+    "A single audio or video stream within a media file."
+    index UInt32 = 0
+    codec_type String = ""
+        "\"audio\", \"video\", etc."
+    codec_name String = ""
+    bitrate_bps UInt64 = 0
+    duration_s Float64 = 0
+    width UInt32 = 0
+        "Video-specific fields (zero / empty for audio streams)."
+    height UInt32 = 0
+    frames_per_second Float64 = 0
+    rotation Int32 = 0
+    display_aspect_ratio String = ""
+        "e.g. \"16:9\""
+    channels UInt32 = 0
+        "Audio-specific fields (zero / empty for video streams)."
+    channel_layout String = ""
+    sample_rate_s UInt64 = 0
+    language_iso_639 String = ""
+        "ISO 639 language code for the stream, when present."
+
+struct ApiMediaMetadata
+    "Audio/video container and per-stream metadata. Mirrors the useful subset of
+    the internal `riviera.MediaMetadata` message."
+    bitrate_bps UInt64 = 0
+    duration_s Float64 = 0
+    creation_time String = ""
+        "Container-level creation time, when present."
+    streams List(ApiMediaStream)?
+
+struct ApiPdfMetadata
+    "PDF document metadata."
+    pages UInt32 = 0
+    width UInt32 = 0
+        "Width / height of the first page, in PDF points."
+    height UInt32 = 0
+
+struct ApiOfficeMetadata
+    "MS Office document metadata. Mirrors the internal `riviera.OfficeMetadata`
+    message. Some fields apply only to specific document types (e.g. `slides`
+    for PowerPoint, `words`/`pages` for Word)."
+    file_type OfficeFileType = office_filetype_unknown
+    creator String = ""
+    company String = ""
+    title String = ""
+    subject String = ""
+    keywords String = ""
+    description String = ""
+    total_edit_time_minutes UInt32 = 0
+    pages UInt32 = 0
+        "Word only."
+    words UInt32 = 0
+    slides UInt32 = 0
+        "PowerPoint only."
+    revision_number String = ""
+
+struct GetMetadataResult
+    metadata_type MetadataType = metadata_type_unknown
+        "The kind of metadata that was extracted for the requested file. Callers
+        should read the matching field of the `metadata` oneof."
+    metadata metadata_union?
+        union
+            "Exactly one variant is populated, corresponding to `metadata_type`."
+            exif ApiExifMetadata
+            media ApiMediaMetadata
+            pdf ApiPdfMetadata
+            office ApiOfficeMetadata
+
+union MetadataExtractionApiV2Error
+    server_error String = ""
+    user_error String = ""
+    unsupported_format_error
+    link_download_disabled_error
+    shared_link_password_protected
+    limit_exceeded_error
+    conversion_failure_error
+    not_found_error
+        "The referenced file does not exist or is not accessible."
+    is_a_folder_error
+        "The target is a folder, not a file."
+
+struct GetMetadataAsyncError
+    error_code ErrorCode = unknown_error
+    error_details MetadataExtractionApiV2Error?
+
+union GetMetadataAsyncCheckResult
+    "Result type for EventBus async check - must end in \"CheckResult\""
+    in_progress
+    complete GetMetadataResult
+    failed GetMetadataAsyncError
+
+route get_metadata_async (GetMetadataArgs, async.LaunchResultBase, Void)
+    "Asynchronous file metadata extraction for supported file formats."
+
+    attrs
+        auth = "app, user"
+        is_preview = true
+        scope = "files.content.read"
+
+route get_metadata_async/check (async.PollArg, GetMetadataAsyncCheckResult, async.PollError)
+    "Returns the status or result of specified get_metadata_async task."
 
     attrs
         auth = "app, user"

--- a/sharing.stone
+++ b/sharing.stone
@@ -1319,6 +1319,7 @@ struct AddFileMemberArgs
     add_message_as_comment Boolean = false
         "If the custom message should be added as a comment on the file. Only meant for Paper files."
     fp_sealed_result String?
+        @common.InternalOnly
         "The FingerprintJS Sealed Client Result value"
 
     example default
@@ -2360,6 +2361,7 @@ struct AddFolderMemberArg
     custom_message String(min_length=1)?
         "Optional message to display to added members in their invitation."
     fp_sealed_result String?
+        @common.InternalOnly
         "The FingerprintJS Sealed Client Result value"
 
     example default

--- a/team.stone
+++ b/team.stone
@@ -504,6 +504,8 @@ union TeamFolderCreateError
         "The provided name cannot be used because it is reserved."
     sync_settings_error files.SyncSettingsError
         "An error occurred setting the sync settings."
+    folder_count_limit_exceeded
+        "The team has reached the maximum number of team folders allowed by its plan."
 
 struct TeamFolderRenameArg extends TeamFolderIdArg
     name String

--- a/team_log.stone
+++ b/team_log.stone
@@ -510,6 +510,44 @@ union LoginMethod
     web_session
     microsoft_oauth
 
+union MediaHubAddingPeoplePolicy
+    "Policy for deciding who can be added to Media Hub content"
+    anyone
+    team_only
+
+union MediaHubDownloadPolicy
+    "Policy for deciding whether Media Hub content can be downloaded"
+    disabled
+    enabled
+
+union MediaHubLinkSharingPolicy
+    "Policy for deciding who Media Hub content can be shared with through links"
+    no_one
+    public
+    team_only
+
+union MediaHubProjectRole
+    "Media Hub project role"
+    editor
+    owner
+    reviewer
+
+union MediaHubSharedLinkAudience
+    "Media Hub shared link audience"
+    no_one
+    public
+    team_only
+
+union MediaHubSharedLinkDownloadSetting
+    "Media Hub shared link download setting"
+    disabled
+    enabled
+
+union MediaHubSharedLinkTargetType
+    "Media Hub shared link target type"
+    bundle
+    project
+
 union MemberRemoveActionType
     delete
     leave
@@ -548,6 +586,12 @@ union MicrosoftLoginPolicy
 
 union MicrosoftOfficeAddinPolicy
     "Microsoft Office addin policy"
+    disabled
+    enabled
+
+union MultiTeamIdentityPolicy
+    "Multi-team identity policy"
+    default
     disabled
     enabled
 
@@ -3660,6 +3704,9 @@ struct FolderOverviewItemUnpinnedDetails
         folder_overview_location_asset = 3
         pinned_items_asset_indices = [3]
 
+struct MediaHubFileDownloadedDetails
+    "Downloaded files in Media Hub."
+
 struct ObjectLabelAddedDetails
     "Added a label."
     label_type LabelType
@@ -5082,6 +5129,70 @@ struct FileTransfersTransferViewDetails
 
     example default
         file_transfer_id = "cap_pid_ft:AAAAAF_3NOyGMTCqXRUoBWKWY1IUOnLLzTUxOeC36XKqaLtq3LYDy6A"
+
+struct MediaHubProjectTeamAddDetails
+    "Added member to Media Hub project."
+
+struct MediaHubProjectTeamDeleteDetails
+    "Removed member from Media Hub project."
+
+struct MediaHubProjectTeamRoleChangedDetails
+    "Changed member role in Media Hub project."
+    previous_role MediaHubProjectRole
+        "Previous Media Hub project role."
+    new_role MediaHubProjectRole
+        "New Media Hub project role."
+
+    example default
+        previous_role = owner
+        new_role = owner
+
+struct MediaHubSharedLinkAudienceChangedDetails
+    "Changed Media Hub shared link audience."
+    target_type MediaHubSharedLinkTargetType
+        "Media Hub shared link target type."
+    previous_value MediaHubSharedLinkAudience
+        "Previous Media Hub shared link audience."
+    new_value MediaHubSharedLinkAudience
+        "New Media Hub shared link audience."
+
+    example default
+        target_type = project
+        previous_value = public
+        new_value = public
+
+struct MediaHubSharedLinkCreatedDetails
+    "Created Media Hub shared link."
+    target_type MediaHubSharedLinkTargetType
+        "Media Hub shared link target type."
+    audience MediaHubSharedLinkAudience
+        "Media Hub shared link audience."
+
+    example default
+        target_type = project
+        audience = public
+
+struct MediaHubSharedLinkDownloadSettingChangedDetails
+    "Changed Media Hub shared link download setting."
+    target_type MediaHubSharedLinkTargetType
+        "Media Hub shared link target type."
+    previous_value MediaHubSharedLinkDownloadSetting
+        "Previous Media Hub shared link download setting."
+    new_value MediaHubSharedLinkDownloadSetting
+        "New Media Hub shared link download setting."
+
+    example default
+        target_type = project
+        previous_value = disabled
+        new_value = disabled
+
+struct MediaHubSharedLinkRevokedDetails
+    "Revoked Media Hub shared link."
+    target_type MediaHubSharedLinkTargetType
+        "Media Hub shared link target type."
+
+    example default
+        target_type = project
 
 struct NoteAclInviteOnlyDetails
     "Changed Paper doc to invite-only."
@@ -6821,6 +6932,39 @@ struct InviteAcceptanceEmailPolicyChangedDetails
         new_value = disabled
         previous_value = disabled
 
+struct MediaHubAddingPeoplePolicyChangedDetails
+    "Changed the policy for adding people to Media Hub content."
+    new_value MediaHubAddingPeoplePolicy
+        "To."
+    previous_value MediaHubAddingPeoplePolicy
+        "From."
+
+    example default
+        new_value = anyone
+        previous_value = anyone
+
+struct MediaHubDownloadPolicyChangedDetails
+    "Changed the policy for downloading Media Hub content."
+    new_value MediaHubDownloadPolicy
+        "To."
+    previous_value MediaHubDownloadPolicy
+        "From."
+
+    example default
+        new_value = disabled
+        previous_value = disabled
+
+struct MediaHubLinkSharingPolicyChangedDetails
+    "Changed the policy for sharing Media Hub content."
+    new_value MediaHubLinkSharingPolicy
+        "To."
+    previous_value MediaHubLinkSharingPolicy
+        "From."
+
+    example default
+        new_value = public
+        previous_value = public
+
 struct MemberRequestsChangePolicyDetails
     "Changed whether users can find team when not invited."
     new_value MemberRequestsPolicy
@@ -6903,6 +7047,17 @@ struct MicrosoftOfficeAddinChangePolicyDetails
     example default
         new_value = disabled
         previous_value = disabled
+
+struct MultiTeamIdentityPolicyChangedDetails
+    "Changed multi-team identity policy for team."
+    new_value MultiTeamIdentityPolicy
+        "New multi-team identity policy."
+    previous_value MultiTeamIdentityPolicy?
+        "Previous multi-team identity policy. Might be missing due to historical data gap."
+
+    example default
+        new_value = default
+        previous_value = default
 
 struct NetworkControlChangePolicyDetails
     "Enabled/disabled network control."
@@ -7958,6 +8113,7 @@ union EventDetails
     folder_overview_description_changed_details FolderOverviewDescriptionChangedDetails
     folder_overview_item_pinned_details FolderOverviewItemPinnedDetails
     folder_overview_item_unpinned_details FolderOverviewItemUnpinnedDetails
+    media_hub_file_downloaded_details MediaHubFileDownloadedDetails
     object_label_added_details ObjectLabelAddedDetails
     object_label_removed_details ObjectLabelRemovedDetails
     object_label_updated_value_details ObjectLabelUpdatedValueDetails
@@ -8124,6 +8280,13 @@ union EventDetails
     file_transfers_transfer_download_details FileTransfersTransferDownloadDetails
     file_transfers_transfer_send_details FileTransfersTransferSendDetails
     file_transfers_transfer_view_details FileTransfersTransferViewDetails
+    media_hub_project_team_add_details MediaHubProjectTeamAddDetails
+    media_hub_project_team_delete_details MediaHubProjectTeamDeleteDetails
+    media_hub_project_team_role_changed_details MediaHubProjectTeamRoleChangedDetails
+    media_hub_shared_link_audience_changed_details MediaHubSharedLinkAudienceChangedDetails
+    media_hub_shared_link_created_details MediaHubSharedLinkCreatedDetails
+    media_hub_shared_link_download_setting_changed_details MediaHubSharedLinkDownloadSettingChangedDetails
+    media_hub_shared_link_revoked_details MediaHubSharedLinkRevokedDetails
     note_acl_invite_only_details NoteAclInviteOnlyDetails
     note_acl_link_details NoteAclLinkDetails
     note_acl_team_link_details NoteAclTeamLinkDetails
@@ -8310,6 +8473,9 @@ union EventDetails
     group_user_management_change_policy_details GroupUserManagementChangePolicyDetails
     integration_policy_changed_details IntegrationPolicyChangedDetails
     invite_acceptance_email_policy_changed_details InviteAcceptanceEmailPolicyChangedDetails
+    media_hub_adding_people_policy_changed_details MediaHubAddingPeoplePolicyChangedDetails
+    media_hub_download_policy_changed_details MediaHubDownloadPolicyChangedDetails
+    media_hub_link_sharing_policy_changed_details MediaHubLinkSharingPolicyChangedDetails
     member_requests_change_policy_details MemberRequestsChangePolicyDetails
     member_send_invite_policy_changed_details MemberSendInvitePolicyChangedDetails
     member_space_limits_add_exception_details MemberSpaceLimitsAddExceptionDetails
@@ -8319,6 +8485,7 @@ union EventDetails
     member_suggestions_change_policy_details MemberSuggestionsChangePolicyDetails
     microsoft_login_change_policy_details MicrosoftLoginChangePolicyDetails
     microsoft_office_addin_change_policy_details MicrosoftOfficeAddinChangePolicyDetails
+    multi_team_identity_policy_changed_details MultiTeamIdentityPolicyChangedDetails
     network_control_change_policy_details NetworkControlChangePolicyDetails
     paper_change_deployment_policy_details PaperChangeDeploymentPolicyDetails
     paper_change_member_link_policy_details PaperChangeMemberLinkPolicyDetails
@@ -9299,6 +9466,12 @@ struct FolderOverviewItemUnpinnedType
 
     example default
         description = "(file_operations) Unpinned item from folder overview"
+
+struct MediaHubFileDownloadedType
+    description String
+
+    example default
+        description = "(file_operations) Downloaded files in Media Hub"
 
 struct ObjectLabelAddedType
     description String
@@ -10295,6 +10468,48 @@ struct FileTransfersTransferViewType
 
     example default
         description = "(sharing) Viewed transfer"
+
+struct MediaHubProjectTeamAddType
+    description String
+
+    example default
+        description = "(sharing) Added member to Media Hub project"
+
+struct MediaHubProjectTeamDeleteType
+    description String
+
+    example default
+        description = "(sharing) Removed member from Media Hub project"
+
+struct MediaHubProjectTeamRoleChangedType
+    description String
+
+    example default
+        description = "(sharing) Changed member role in Media Hub project"
+
+struct MediaHubSharedLinkAudienceChangedType
+    description String
+
+    example default
+        description = "(sharing) Changed Media Hub shared link audience"
+
+struct MediaHubSharedLinkCreatedType
+    description String
+
+    example default
+        description = "(sharing) Created Media Hub shared link"
+
+struct MediaHubSharedLinkDownloadSettingChangedType
+    description String
+
+    example default
+        description = "(sharing) Changed Media Hub shared link download setting"
+
+struct MediaHubSharedLinkRevokedType
+    description String
+
+    example default
+        description = "(sharing) Revoked Media Hub shared link"
 
 struct NoteAclInviteOnlyType
     description String
@@ -11412,6 +11627,24 @@ struct InviteAcceptanceEmailPolicyChangedType
     example default
         description = "(team_policies) Changed invite accept email policy for team"
 
+struct MediaHubAddingPeoplePolicyChangedType
+    description String
+
+    example default
+        description = "(team_policies) Changed the policy for adding people to Media Hub content"
+
+struct MediaHubDownloadPolicyChangedType
+    description String
+
+    example default
+        description = "(team_policies) Changed the policy for downloading Media Hub content"
+
+struct MediaHubLinkSharingPolicyChangedType
+    description String
+
+    example default
+        description = "(team_policies) Changed the policy for sharing Media Hub content"
+
 struct MemberRequestsChangePolicyType
     description String
 
@@ -11465,6 +11698,12 @@ struct MicrosoftOfficeAddinChangePolicyType
 
     example default
         description = "(team_policies) Enabled/disabled Microsoft Office add-in"
+
+struct MultiTeamIdentityPolicyChangedType
+    description String
+
+    example default
+        description = "(team_policies) Changed multi-team identity policy for team"
 
 struct NetworkControlChangePolicyType
     description String
@@ -12354,6 +12593,8 @@ union EventType
         "(file_operations) Pinned item to folder overview"
     folder_overview_item_unpinned FolderOverviewItemUnpinnedType
         "(file_operations) Unpinned item from folder overview"
+    media_hub_file_downloaded MediaHubFileDownloadedType
+        "(file_operations) Downloaded files in Media Hub"
     object_label_added ObjectLabelAddedType
         "(file_operations) Added a label"
     object_label_removed ObjectLabelRemovedType
@@ -12686,6 +12927,20 @@ union EventType
         "(sharing) Sent transfer"
     file_transfers_transfer_view FileTransfersTransferViewType
         "(sharing) Viewed transfer"
+    media_hub_project_team_add MediaHubProjectTeamAddType
+        "(sharing) Added member to Media Hub project"
+    media_hub_project_team_delete MediaHubProjectTeamDeleteType
+        "(sharing) Removed member from Media Hub project"
+    media_hub_project_team_role_changed MediaHubProjectTeamRoleChangedType
+        "(sharing) Changed member role in Media Hub project"
+    media_hub_shared_link_audience_changed MediaHubSharedLinkAudienceChangedType
+        "(sharing) Changed Media Hub shared link audience"
+    media_hub_shared_link_created MediaHubSharedLinkCreatedType
+        "(sharing) Created Media Hub shared link"
+    media_hub_shared_link_download_setting_changed MediaHubSharedLinkDownloadSettingChangedType
+        "(sharing) Changed Media Hub shared link download setting"
+    media_hub_shared_link_revoked MediaHubSharedLinkRevokedType
+        "(sharing) Revoked Media Hub shared link"
     note_acl_invite_only NoteAclInviteOnlyType
         "(sharing) Changed Paper doc to invite-only (deprecated, no longer logged)"
     note_acl_link NoteAclLinkType
@@ -13058,6 +13313,12 @@ union EventType
         "(team_policies) Changed integration policy for team"
     invite_acceptance_email_policy_changed InviteAcceptanceEmailPolicyChangedType
         "(team_policies) Changed invite accept email policy for team"
+    media_hub_adding_people_policy_changed MediaHubAddingPeoplePolicyChangedType
+        "(team_policies) Changed the policy for adding people to Media Hub content"
+    media_hub_download_policy_changed MediaHubDownloadPolicyChangedType
+        "(team_policies) Changed the policy for downloading Media Hub content"
+    media_hub_link_sharing_policy_changed MediaHubLinkSharingPolicyChangedType
+        "(team_policies) Changed the policy for sharing Media Hub content"
     member_requests_change_policy MemberRequestsChangePolicyType
         "(team_policies) Changed whether users can find team when not invited"
     member_send_invite_policy_changed MemberSendInvitePolicyChangedType
@@ -13076,6 +13337,8 @@ union EventType
         "(team_policies) Enabled/disabled Microsoft login for team"
     microsoft_office_addin_change_policy MicrosoftOfficeAddinChangePolicyType
         "(team_policies) Enabled/disabled Microsoft Office add-in"
+    multi_team_identity_policy_changed MultiTeamIdentityPolicyChangedType
+        "(team_policies) Changed multi-team identity policy for team"
     network_control_change_policy NetworkControlChangePolicyType
         "(team_policies) Enabled/disabled network control"
     paper_change_deployment_policy PaperChangeDeploymentPolicyType
@@ -13572,6 +13835,8 @@ union EventTypeArg
         "(file_operations) Pinned item to folder overview"
     folder_overview_item_unpinned
         "(file_operations) Unpinned item from folder overview"
+    media_hub_file_downloaded
+        "(file_operations) Downloaded files in Media Hub"
     object_label_added
         "(file_operations) Added a label"
     object_label_removed
@@ -13904,6 +14169,20 @@ union EventTypeArg
         "(sharing) Sent transfer"
     file_transfers_transfer_view
         "(sharing) Viewed transfer"
+    media_hub_project_team_add
+        "(sharing) Added member to Media Hub project"
+    media_hub_project_team_delete
+        "(sharing) Removed member from Media Hub project"
+    media_hub_project_team_role_changed
+        "(sharing) Changed member role in Media Hub project"
+    media_hub_shared_link_audience_changed
+        "(sharing) Changed Media Hub shared link audience"
+    media_hub_shared_link_created
+        "(sharing) Created Media Hub shared link"
+    media_hub_shared_link_download_setting_changed
+        "(sharing) Changed Media Hub shared link download setting"
+    media_hub_shared_link_revoked
+        "(sharing) Revoked Media Hub shared link"
     note_acl_invite_only
         "(sharing) Changed Paper doc to invite-only (deprecated, no longer logged)"
     note_acl_link
@@ -14276,6 +14555,12 @@ union EventTypeArg
         "(team_policies) Changed integration policy for team"
     invite_acceptance_email_policy_changed
         "(team_policies) Changed invite accept email policy for team"
+    media_hub_adding_people_policy_changed
+        "(team_policies) Changed the policy for adding people to Media Hub content"
+    media_hub_download_policy_changed
+        "(team_policies) Changed the policy for downloading Media Hub content"
+    media_hub_link_sharing_policy_changed
+        "(team_policies) Changed the policy for sharing Media Hub content"
     member_requests_change_policy
         "(team_policies) Changed whether users can find team when not invited"
     member_send_invite_policy_changed
@@ -14294,6 +14579,8 @@ union EventTypeArg
         "(team_policies) Enabled/disabled Microsoft login for team"
     microsoft_office_addin_change_policy
         "(team_policies) Enabled/disabled Microsoft Office add-in"
+    multi_team_identity_policy_changed
+        "(team_policies) Changed multi-team identity policy for team"
     network_control_change_policy
         "(team_policies) Enabled/disabled network control"
     paper_change_deployment_policy


### PR DESCRIPTION
Change Notes:

common Namespace
- Add InternalOnly annotation

files Namespace
- Update ThumbnailSize union to mark w3200h2400 as @common.InternalOnly
- Update ThumbnailArg struct to mark quality as @common.InternalOnly
- Update ThumbnailV2Arg struct to mark quality as @common.InternalOnly

riviera Namespace
- Add get_metadata_async, get_metadata_async/check routes
- Add GetMetadataArgs, ApiExifGpsMetadata, ApiExifMetadata, ApiMediaStream, ApiMediaMetadata, ApiPdfMetadata, ApiOfficeMetadata, GetMetadataResult, GetMetadataAsyncError structs
- Add OfficeFileType, MetadataType, MetadataExtractionApiV2Error, GetMetadataAsyncCheckResult unions
- Update ContentApiV2Error union to include not_found_error, is_a_folder_error
- Update MarkdownConversionApiV2Error union to include not_found_error, is_a_folder_error
- Update Comments

sharing Namespace
- Update AddFileMemberArgs struct to mark fp_sealed_result as @common.InternalOnly
- Update AddFolderMemberArg struct to mark fp_sealed_result as @common.InternalOnly

team Namespace
- Update TeamFolderCreateError union to include folder_count_limit_exceeded

team_log Namespace
- Add MediaHubFileDownloadedDetails, MediaHubProjectTeamAddDetails, MediaHubProjectTeamDeleteDetails, MediaHubProjectTeamRoleChangedDetails, MediaHubSharedLinkAudienceChangedDetails, MediaHubSharedLinkCreatedDetails, MediaHubSharedLinkDownloadSettingChangedDetails, MediaHubSharedLinkRevokedDetails, MediaHubAddingPeoplePolicyChangedDetails, MediaHubDownloadPolicyChangedDetails, MediaHubLinkSharingPolicyChangedDetails, MultiTeamIdentityPolicyChangedDetails, MediaHubFileDownloadedType, MediaHubProjectTeamAddType, MediaHubProjectTeamDeleteType, MediaHubProjectTeamRoleChangedType, MediaHubSharedLinkAudienceChangedType, MediaHubSharedLinkCreatedType, MediaHubSharedLinkDownloadSettingChangedType, MediaHubSharedLinkRevokedType, MediaHubAddingPeoplePolicyChangedType, MediaHubDownloadPolicyChangedType, MediaHubLinkSharingPolicyChangedType, MultiTeamIdentityPolicyChangedType structs
- Add MediaHubAddingPeoplePolicy, MediaHubDownloadPolicy, MediaHubLinkSharingPolicy, MediaHubProjectRole, MediaHubSharedLinkAudience, MediaHubSharedLinkDownloadSetting, MediaHubSharedLinkTargetType, MultiTeamIdentityPolicy unions
- Update EventDetails union to include the new Media Hub and multi-team identity detail variants
