### PR TITLE
Replace PAT with SDK Updater GitHub App

### DIFF
--- a/.github/workflows/dispatch_spec_update.yml
+++ b/.github/workflows/dispatch_spec_update.yml
@@ -19,7 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         repository:
-          - dropbox-sdk-python
+          - dropbox/dropbox-sdk-python
+          - dropbox/dropbox-sdk-js
+          - dropbox/dropbox-sdk-dotnet
 
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/dispatch_spec_update.yml
+++ b/.github/workflows/dispatch_spec_update.yml
@@ -6,7 +6,9 @@ on:
     branches:
       - main
 
-permissions: {}
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   dispatch:
@@ -17,17 +19,36 @@ jobs:
       fail-fast: false
       matrix:
         repository:
-          - dropbox/dropbox-sdk-python
-          - dropbox/dropbox-sdk-js
-          - dropbox/dropbox-sdk-dotnet
-          - dropbox/dropbox-api-v2-explorer
+          - dropbox-sdk-python
 
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-api-spec-repo
+          aws-region: us-west-2
+
+      - name: Fetch GitHub App credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
+        with:
+          secret-ids: |
+            SDK_UPDATER,sdk-updater-github-app
+          parse-json-secrets: true
+
+      - name: Generate GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ env.SDK_UPDATER_CLIENT_ID }}
+          private-key: ${{ env.SDK_UPDATER_PRIVATE_KEY }}
+          owner: dropbox
+          repositories: ${{ matrix.repository }}
+
       - name: Dispatch spec update
         uses: peter-evans/repository-dispatch@v4
         with:
-          token: ${{ secrets.SPEC_UPDATE_TOKEN }}
-          repository: ${{ matrix.repository }}
+          token: ${{ steps.app-token.outputs.token }}
+          repository: dropbox/${{ matrix.repository }}
           event-type: spec_update
           client-payload: >-
             {


### PR DESCRIPTION
## Summary
- Replace classic PAT (`SPEC_UPDATE_TOKEN`) with SDK Updater GitHub App for dispatching spec updates
- Authenticate via AWS OIDC → Secrets Manager → GitHub App installation token
- Scoped to `dropbox-sdk-python` initially for testing; other SDKs will be added once validated

## Test plan
- [ ] Trigger workflow manually via `gh workflow run` on this branch
- [ ] Verify AWS OIDC auth succeeds
- [ ] Verify GitHub App token is minted and `repository_dispatch` lands in dropbox-sdk-python
- [ ] Once validated, add remaining SDK repos to the matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)