### PR TITLE
Fix repo prefix slug in dispatch workflow

### DIFF
--- a/.github/workflows/dispatch_spec_update.yml
+++ b/.github/workflows/dispatch_spec_update.yml
@@ -19,9 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         repository:
-          - dropbox/dropbox-sdk-python
-          - dropbox/dropbox-sdk-js
-          - dropbox/dropbox-sdk-dotnet
+          - dropbox-sdk-python
+          - dropbox-sdk-js
+          - dropbox-sdk-dotnet
 
     steps:
       - name: Configure AWS credentials


### PR DESCRIPTION
## Summary
- Fix repository prefix issue that caused `repository_dispatch` to fail when triggered automatically from the pipeline

## Test plan
- [ ] Push to main triggers the workflow successfully
- [ ] `repository_dispatch` lands in dropbox-sdk-python

🤖 Generated with [Claude Code](https://claude.com/claude-code)