### PR TITLE
Add dropbox-sdk-go-unofficial to spec update dispatch matrix

### DIFF
--- a/.github/workflows/dispatch_spec_update.yml
+++ b/.github/workflows/dispatch_spec_update.yml
@@ -22,6 +22,7 @@ jobs:
           - dropbox-sdk-python
           - dropbox-sdk-js
           - dropbox-sdk-dotnet
+          - dropbox-sdk-go-unofficial
 
     steps:
       - name: Configure AWS credentials


### PR DESCRIPTION
## Summary
- Add `dropbox-sdk-go-unofficial` to the repository dispatch matrix so spec updates trigger the Go SDK's new `spec_update` workflow

## Test plan
- [ ] Verify the GitHub App has installation access to `dropbox/dropbox-sdk-go-unofficial`
- [ ] Trigger via `workflow_dispatch` and confirm the Go SDK repo receives the `spec_update` event

🤖 Generated with [Claude Code](https://claude.com/claude-code)