### PR TITLE
Add API Explorer to spec update dispatch matrix

### DIFF
--- a/.github/workflows/dispatch_spec_update.yml
+++ b/.github/workflows/dispatch_spec_update.yml
@@ -23,6 +23,7 @@ jobs:
           - dropbox-sdk-js
           - dropbox-sdk-dotnet
           - dropbox-sdk-go-unofficial
+          - dropbox-api-v2-explorer
 
     steps:
       - name: Configure AWS credentials


### PR DESCRIPTION
## Summary

- add `dropbox-api-v2-explorer` to the repository dispatch matrix
- allow API spec updates on `main` to trigger the Explorer's `spec_update` workflow

## Test plan

- [x] Validate the workflow change with `actionlint` (ignoring the pre-existing `create-github-app-token` metadata warning)
- [x] Verify the SDK Updater GitHub App has installation access to `dropbox/dropbox-api-v2-explorer`
- [x] Trigger via `workflow_dispatch` and confirm the Explorer receives the `spec_update` event

## Follow-up

The Explorer currently validates dispatched spec updates but cannot create its generated PR because `SPEC_UPDATE_TOKEN` is not configured. That receiver-side authentication must be repaired separately.
