### PR TITLE
Add Java, Obj-C, and Swift SDKs to spec update dispatch matrix

### DIFF
--- a/.github/workflows/dispatch_spec_update.yml
+++ b/.github/workflows/dispatch_spec_update.yml
@@ -23,6 +23,9 @@ jobs:
           - dropbox-sdk-js
           - dropbox-sdk-dotnet
           - dropbox-sdk-go-unofficial
+          - dropbox-sdk-java
+          - dropbox-sdk-obj-c
+          - SwiftyDropbox
           - dropbox-api-v2-explorer
 
     steps:


### PR DESCRIPTION
## Summary
- Add `dropbox-sdk-java`, `dropbox-sdk-obj-c`, and `SwiftyDropbox` to the repository dispatch matrix
- These repos now have `spec_update.yml` workflows ready to receive the `spec_update` event

## Test plan
- [ ] Verify the GitHub App has installation access to all three repos
- [ ] Trigger via `workflow_dispatch` and confirm all repos receive the event

🤖 Generated with [Claude Code](https://claude.com/claude-code)